### PR TITLE
Pragma statement fix

### DIFF
--- a/src/sdc/ast/statement.d
+++ b/src/sdc/ast/statement.d
@@ -322,7 +322,7 @@ class ScopeGuardStatement : Node
 class PragmaStatement : Node
 {
     Pragma thePragma;
-    Statement statement;
+    Statement statement; // Optional
 }
 
 class MixinStatement : Node

--- a/src/sdc/gen/statement.d
+++ b/src/sdc/gen/statement.d
@@ -386,5 +386,8 @@ void genConditionalStatement(ast.ConditionalStatement statement, Module mod)
 void genPragmaStatement(ast.PragmaStatement statement, Module mod)
 {
     genPragma(statement.thePragma, mod);
-    genStatement(statement.statement, mod);
+    
+    if (statement.statement !is null) {
+        genStatement(statement.statement, mod);
+    }
 }

--- a/src/sdc/parser/statement.d
+++ b/src/sdc/parser/statement.d
@@ -283,7 +283,12 @@ PragmaStatement parsePragmaStatement(TokenStream tstream)
     statement.location = tstream.peek.location;
     
     statement.thePragma = parsePragma(tstream);
-    statement.statement = parseStatement(tstream);
+    
+    if (tstream.peek.type == TokenType.Semicolon) {
+        tstream.getToken();
+    } else {
+        statement.statement = parseStatement(tstream);
+    }
     return statement;
 }
 


### PR DESCRIPTION
Fixes pragma statement in the form `pragma(thePragma, ...);`. `pragma(msg, ...)` now works.

Top-level simple form pragma "declarations" still crash.
