### PR TITLE
Change license to MIT in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ This is the home of a [D](http://d-programming-language.org/) compiler.
 SDC is at the moment, particularly stupid; it is a work in progress. Feel free to poke around, but don't expect it to compile your code.
 I don't know what I'm doing in terms of compiler writing. If you find some horrible design decision, that's most likely why.
 
-The code is released under the GPL (see the LICENCE file for more details).
+The code is released under the MIT license (see the LICENCE file for more details).
 Contact me at b.helyer@gmail.com
 
 Last tested with: DMD releases `2.057` and `2.058` on the 6th of March.


### PR DESCRIPTION
Just swapped the license name.
