### PR TITLE
fix build on ubuntu 11.10: change order of LDFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ EXE = bin/sdc
 
 PHOBOS2 = -lphobos2
 LIBLLVM = -L-L`llvm-config --libdir` `llvm-config --libs | sed 's/-L/-L-L/g' | sed 's/-l/-L-l/g' -`
-LDFLAGS = -L-lstdc++ $(LIBLLVM) 
+LDFLAGS = $(LIBLLVM) -L-lstdc++ 
 
 ifeq ($(PLATFORM),Linux)
 LDFLAGS += -L-ldl


### PR DESCRIPTION
I just tried to build sdc on my ubuntu 11.10 box and it failed with a hole lot of 
undefined reference errors. I applied the proposed fix and it works like a charm now.
