### PR TITLE
Allow static linking of sdc binary to avoid system .so dependency hell.

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,7 +13,11 @@ ifdef LD_PATH
 	LDFLAGS += $(addprefix -L, $(LD_PATH))
 endif
 
-LDFLAGS += -lphobos2 $(LIBD_LIB) $(LLVM_LIB)
+ifdef STATICLINK
+	LDFLAGS += $(LIBD_LIB) $(LLVM_LIB) -l:libphobos2.a
+else
+	LDFLAGS += -lphobos2 $(LIBD_LIB) $(LLVM_LIB)
+endif
 
 PLATFORM = $(shell uname -s)
 ifeq ($(PLATFORM),Linux)


### PR DESCRIPTION
On my system, dynamic linking and dmd don't work together, it produces a huge unrunnable mess. With this patch, I can solve the problem by running:

```
make STATICLINK=1 LD_PATH=/path/to/my/phobos/generated/linux/release/64
```

Then it can successfully link a runnable sdc.
