### PR TITLE
Add snap package definition for SDC

### DIFF
--- a/snap-config/dmd.conf
+++ b/snap-config/dmd.conf
@@ -1,0 +1,5 @@
+[Environment32]
+DFLAGS=-I%@P%/../import/dmd -L-L%@P%/../lib/dmd -L--export-dynamic
+
+[Environment64]
+DFLAGS=-I%@P%/../import/dmd -L-L%@P%/../lib/dmd -L--export-dynamic -fPIC

--- a/snap-config/sdc.conf
+++ b/snap-config/sdc.conf
@@ -1,0 +1,4 @@
+{
+	"includePath": ["/snap/sdc/current/import", "."],
+	"libPath": ["/snap/sdc/current/lib"],
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,141 @@
+name: sdc
+version: HEAD
+summary: A sane D compiler with an LLVM backend
+description: |
+    SDC is a from-scratch implementation of a D compiler written itself
+    in the D programming language, while using LLVM as its backend.  It
+    is currently under heavy development, and hence provides a limited
+    feature set that is not yet suitable for production work.
+
+    A major project goal is to provide a D compiler as a library (libd)
+    so as to support the development of a much wider range of D tools.
+
+confinement: classic
+grade: devel
+
+apps:
+  sdc:
+    command: bin/sdc
+
+parts:
+  sdc:
+    source: .
+    source-commit: HEAD
+    source-type: git
+    plugin: make
+    make-parameters:
+    - LLVM_CONFIG=../../../stage/bin/llvm-config
+    - DFLAGS=-m64 -w -debug -g -unittest
+    - LDFLAGS=-L../../../stage/lib
+    artifacts:
+    - bin
+    - import
+    - lib
+    - sdlib
+    - LICENCE
+    organize:
+      sdlib: import
+      LICENCE: snap/license.txt
+    stage:
+    - -bin/sdc.conf
+    - -import/sdc/*.mak
+    build-packages:
+    - gcc
+    - make
+    - nasm
+    after:
+    - dmd
+    - druntime
+    - phobos
+    - llvm
+    - snap-config
+
+  snap-config:
+    plugin: dump
+    source: snap-config
+    organize:
+      dmd.conf: bin/dmd.conf
+      sdc.conf: bin/sdc.conf
+    prime:
+    - -bin/dmd.conf
+
+  dmd:
+    source: https://github.com/dlang/dmd.git
+    source-tag: &dmd-version v2.072.2
+    source-type: git
+    plugin: make
+    makefile: posix.mak
+    make-parameters:
+    - AUTO_BOOTSTRAP=1
+    - RELEASE=1
+    organize:
+      linux/bin32: bin
+      linux/bin64: bin
+    stage:
+    - -bin/dmd.conf
+    - -linux
+    - -samples
+    prime:
+    - -*
+    build-packages:
+    - curl
+    - g++
+
+  druntime:
+    source: https://github.com/dlang/druntime.git
+    source-tag: *dmd-version
+    source-type: git
+    plugin: make
+    makefile: posix.mak
+    make-parameters:
+    - DMD=../../dmd/build/src/dmd
+    organize:
+      src/druntime/import: import/dmd
+    stage:
+    - -src
+    prime:
+    - -*
+    build-packages:
+    - gcc
+    after:
+    - dmd
+
+  phobos:
+    source: https://github.com/dlang/phobos.git
+    source-tag: *dmd-version
+    source-type: git
+    plugin: make
+    makefile: posix.mak
+    make-parameters:
+    - DMD=../../dmd/build/src/dmd
+    - DRUNTIME_PATH=../../druntime/build
+    - VERSION=../../dmd/build/VERSION
+    organize:
+      linux/lib32: lib
+      linux/lib64: lib
+      src/phobos: import/dmd
+    stage:
+    - -lib/libphobos2.so
+    - -lib/libphobos2.so.0.72.2
+    - -linux
+    - -src
+    prime:
+    - -*
+    build-packages:
+    - gcc
+    after:
+    - dmd
+    - druntime
+
+  llvm:
+    source: http://releases.llvm.org/3.9.1/llvm-3.9.1.src.tar.xz
+    source-checksum: sha3_512/cd1bd92c999aa82b79e033d5c6409efa3437e9b6bc22840c3cc9105447e2f96203096cd2857ada8de2d327a43cb423d09ec8b71edd16f7c9b72f5221408cd199
+    plugin: cmake
+    configflags:
+    - -DCMAKE_BUILD_TYPE=Release
+    - -DLLVM_BINUTILS_INCDIR=/usr/include
+    prime:
+    - -*
+    build-packages:
+    - binutils-dev
+    - g++


### PR DESCRIPTION
***Note** this is submitted on spec in the hope that it might be useful, and as a proof of concept.  No worries if it's not wanted ;-)  It's also straightforward to implement this as an 'external' snap package in its own git repo, which just clones SDC from its own git repo.*

This package definition provides a complete recipe for a bootstrapped build of SDC, with fresh builds of DMD/druntime/phobos 2.072.2 and LLVM 3.9.1.  The resulting SDC and accompanying libraries are then packaged into a classic snap (meaning its confinement allows it to access the host system for access to development libraries, toolchains, etc.).

This should provide a straightforward way to test-build SDC as well as providing an easy way to install the compiler that should be viable for any Linux distribution with a sufficiently up-to-date snapd package.

Some notes on the parts of the snap package:

  * `llvm` downloads an LLVM source package and performs a full build which used as a build dependency by `sdc`, but which is not necessary to include in the final snap package.

  * `dmd` builds a fresh copy of DMD 2.072.2, which is then used to build `druntime` and `phobos`.  Together these are used to build `sdc` itself, but they are not included in the final snap package.

  * ~~`dmd-config` provides a `dmd.conf` that will be used by the bootstrap DMD in order to be able to access the bootstrap druntime and phobos.  It is not included in the final snap package.~~

  * `snap-config` provides a `dmd.conf` that will be used by the bootstrap DMD in order to be able to access the bootstrap druntime and phobos, and an `sdc.conf` that specifies how the packaged SDC can access its associated libraries and import locations.  Only the `sdc.conf` is included in the final snap package.

  * `sdc` builds the actual SDC compiler from the HEAD of the git repo, using the bootstrap `dmd`, `druntime` and `phobos`, and with `llvm` as a build dependency.  The results included in the final snap package are specified in the `artifacts:` section, with some of them being renamed according to the `organize:` config.

  * ~~`sdc-config` provides an `sdc.conf` suitable for inclusion in the snap package, which should allow the installed SDC to find its associated libraries and import locations.~~

The snap `version:` is given as HEAD (yes, the actual string `HEAD`!), since for now there is no mechanism to extract more informative version information from git.  Support for this is apparently in the `snapcraft` roadmap so it should be possible to replace `HEAD` at some point.