### PR TITLE
Implement extern(C) mangling for variables.

### DIFF
--- a/src/d/semantic/symbol.d
+++ b/src/d/semantic/symbol.d
@@ -486,19 +486,31 @@ struct SymbolAnalyzer {
 		v.mangle = v.name;
 		static if(is(V : Variable)) {
 			if (v.storage == Storage.Static) {
-				assert(v.linkage == Linkage.D, "I mangle only D !");
-				
-				auto name = v.name.toString(context);
-				
-				import d.semantic.mangler;
-				auto mangle = TypeMangler(pass).visit(v.type);
-				
-				import std.conv;
-				mangle = "_D" ~ manglePrefix
-					~ to!string(name.length) ~ name
-					~ mangle;
-				
-				v.mangle = context.getName(mangle);
+				switch (v.linkage) with(Linkage) {
+					case D:
+						auto name = v.name.toString(context);
+						import d.semantic.mangler;
+						auto mangle = TypeMangler(pass).visit(v.type);
+
+						import std.conv;
+						mangle = "_D" ~ manglePrefix
+							~ to!string(name.length) ~ name
+							~ mangle;
+
+						v.mangle = context.getName(mangle);
+						break;
+
+					case C:
+						v.mangle = v.name;
+						break;
+
+					default:
+						import std.conv;
+						assert(
+							0,
+							"Linkage " ~ to!string(v.linkage) ~ " is not supported",
+						);
+				}
 			}
 		}
 		

--- a/test/runner/test0196.d
+++ b/test/runner/test0196.d
@@ -1,0 +1,14 @@
+//T compiles:yes
+//T has-passed:yes
+//T retval:138
+// extern(C) variable and function.
+
+extern(C) int bar = 138;
+
+extern(C) int foo() {
+	return bar;
+}
+
+int main() {
+	return foo();
+}


### PR DESCRIPTION
extern(C) mangling is useful for interfacing with C. It enables

    extern(C) int bar;

to compile.