### PR TITLE
Added a build description for Nix along with readme instructions for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ If you do not want to compile SDC on your own, you can use the [automatic genera
 Assume you have a `test.d` file in your local directory, you can compile it using the Docker image with this command:
 `docker run -ti -v $(pwd):/src dlanguage/sdc test.d`
 
+Building SDC as a Nix package
+=======
+On Linux, you can also use the [Nix package manager](https://nixos.org) to automatically fetch dependencies and build SDC for you.
+You may need to use the unstable nix channel, to have a new enough `dmd` to build SDC. Clone or download this repository.
+
+To build the executable, run `nix-build -E "(import <nixpkgs> {}).callPackage ./. {}"` or
+`nix-build -E "(import <nixpkgs> {}).callPackage ./. {dflags=\"-O -release\";}"` from the project root directory.
+
 ### Setup
 Extract the LLVM DLL binary archive to the SDC repository, then build with `make -f Makefile.windows`.
 When running SDC, make sure `gcc`, `llc` and `opt` are available in your PATH.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, dmd, nasm, llvmPackages, dflags ? null}:
+stdenv.mkDerivation
+{   name="sdc";
+    src= lib.cleanSource ./.;
+    nativeBuildInputs = [dmd llvmPackages.bintools];
+
+    preBuild= let
+        dflagsDecl = if dflags == null then "" else "DFLAGS=\"${dflags}\"";
+    in
+    ''
+        makeFlagsArray+=(NATIVE_DMD_IMPORTS="-I${dmd}/include/dmd" ${dflagsDecl})
+    '';
+    buildInputs = [nasm llvmPackages.bintools];
+
+
+    installPhase =
+    ''
+        mkdir $out
+        cp -r bin $out/bin
+        cp -r lib $out/lib
+        rm sdlib/*.mak
+        mkdir $out/include
+        cp -r sdlib $out/include/sdc
+        dd >$out/bin/sdc.conf << EOF
+        {
+            "includePath": ["$out/include/sdc", "."],
+            "libPath": ["$out/lib"],
+        }
+        EOF
+    '';
+}

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation
     ''
         makeFlagsArray+=(NATIVE_DMD_IMPORTS="-I${dmd}/include/dmd" ${dflagsDecl})
     '';
-    buildInputs = [nasm llvmPackages.bintools];
+    buildInputs = [nasm llvmPackages.libllvm];
 
 
     installPhase =


### PR DESCRIPTION
You have done a good job making your build system obey common UNIX conventions. This is one of the first Nix derivations (package descriptions) I have done and yet I was able to get it working.

I tested on NixOS so it's likely it works on any X86_64 Linux, but I recommend testing that before merging.