### PR TITLE
Makefiles: Fix linking with LDC

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,4 @@
 DMD ?= dmd
-GCC ?= gcc
 NASM ?= nasm
 RDMD ?= rdmd
 
@@ -20,8 +19,6 @@ LDFLAGS ?=
 ifdef LD_PATH
 	override LDFLAGS += $(addprefix -L, $(LD_PATH))
 endif
-
-override LDFLAGS += -lphobos2
 
 ifeq ($(PLATFORM),Linux)
 	LD_LLD = $(shell which ld.lld | xargs basename)

--- a/src/sdc.mak
+++ b/src/sdc.mak
@@ -29,11 +29,11 @@ obj/driver/%.o: src/driver/%.d
 
 $(SDC): obj/driver/sdc.o $(LIBSDC) $(LIBD) $(LIBD_LLVM) $(LIBSDMD) $(LIBCONFIG) $(LIBSOURCE)
 	@mkdir -p bin
-	$(GCC) -o "$@" $+ $(ARCHFLAG) $(LDFLAGS) $(LDFLAGS_LLVM)
+	$(DMD) -of"$@" $+ $(DFLAGS) $(addprefix -Xcc=,$(LDFLAGS)) $(addprefix -Xcc=,$(LDFLAGS_LLVM))
 
 $(SDUNIT): obj/driver/sdunit.o $(LIBSDC) $(LIBD) $(LIBD_LLVM) $(LIBSDMD) $(LIBCONFIG) $(LIBSOURCE)
 	@mkdir -p bin
-	$(GCC) -o "$@" $+ $(ARCHFLAG) $(LDFLAGS) $(LDFLAGS_LLVM)
+	$(DMD) -of"$@" $+ $(DFLAGS) $(addprefix -Xcc=,$(LDFLAGS)) $(addprefix -Xcc=,$(LDFLAGS_LLVM))
 
 bin/sdconfig:
 	@mkdir -p bin

--- a/src/sdfmt.mak
+++ b/src/sdfmt.mak
@@ -13,7 +13,7 @@ $(LIBSDFMT): obj/format.o
 
 $(SDFMT): obj/driver/sdfmt.o $(LIBSDFMT) $(LIBCONFIG) $(LIBSOURCE)
 	@mkdir -p bin
-	$(GCC) -o "$@" $^ $(ARCHFLAG) $(LDFLAGS)
+	$(DMD) -of"$@" $^ $(DFLAGS) $(addprefix -Xcc=,$(LDFLAGS))
 
 check-libfmt: $(LIBSDFMT_SRC)
 	$(RDMD) $(DFLAGS) -unittest -i $(addprefix --extra-file=, $^) --eval="/* Do nothing */"


### PR DESCRIPTION
Where the default lib isn't called `phobos2`, but consists of 2 separate `phobos2-ldc` and `druntime-ldc`.

Let the D compiler handle the linking (it knows which libs to add and where they are) and forward the previous gcc args (`LDFLAGS*`) directly to the underlying gcc invocation via `-Xcc`.

This gets `sdfmt` to build successfully with LDC; `sdlib` still fails due to an `object.ClassInfo` vs. `d.rt.object.ClassInfo` conflict for the `__sd_class_downcast` signatures.