### PR TITLE
First go at at a dub.json for sdfmt.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,13 @@
+{
+    "name": "sdc",
+    "description": "The snazzy D compiler. Currently only sdfmt (sdc:sdfmt) is available via dub",
+    "targetType": "none",
+    "subPackages": [
+      {
+        "name": "sdfmt",
+        "targetType": "executable",
+        "mainSourceFile": "src/driver/sdfmt.d",
+        "sourcePaths": ["src/format/", "src/source", "src/config"]
+      }
+    ]
+}


### PR DESCRIPTION
Try locally with `dub run sdc:sdfmt`

Once this is added to the registry people can use it using the above command too.