### PR TITLE
dub: Fix sdfmt build with LDC

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,6 +7,7 @@
 		{
 			"name": "sdfmt",
 			"targetType": "executable",
+			"targetName": "sdfmt",
 			"mainSourceFile": "src/driver/sdfmt.d",
 			"sourcePaths": ["src/format/", "src/source", "src/config"]
 		}

--- a/src/format/parser.d
+++ b/src/format/parser.d
@@ -186,11 +186,12 @@ private:
 	}
 
 	auto indent(uint level = 1) {
-		return wrappedGuard!((p, l) => p.builder.indent(l))(level);
+		return wrappedGuard!((Parser* p, uint l) => p.builder.indent(l))(level);
 	}
 
 	auto unindent(uint level = 1) {
-		return wrappedGuard!((p, l) => p.builder.unindent(l))(level);
+		return
+			wrappedGuard!((Parser* p, uint l) => p.builder.unindent(l))(level);
 	}
 
 	import format.span;
@@ -212,7 +213,7 @@ private:
 
 	auto block() {
 		emitRawContent();
-		return wrappedGuard!(p => p.builder.block())();
+		return wrappedGuard!((Parser* p) => p.builder.block())();
 	}
 
 	/**


### PR DESCRIPTION
Working around the 'dual context' requirement, which seems to be a compiler bug - the lambdas don't require any context, and when making them non-templates via explicit param types, it works.

Also make sure the produced binary is named `sdfmt`, not `sdc_sdfmt`.