### PR TITLE
recursively add toHash `@safe` and nothrow

### DIFF
--- a/src/config/hash.d
+++ b/src/config/hash.d
@@ -30,7 +30,8 @@ enum isHashable(T) = is(typeof(const(T).init.toHash()) : hash_t);
 struct Hasher {
 	ulong state = 0;
 
-	hash_t mix(ulong k) {
+	@safe @nogc
+	hash_t mix(ulong k) pure nothrow {
 		import util.math;
 		auto hi = mulhi(state, k);
 		auto lo = state * k;

--- a/src/config/heap.d
+++ b/src/config/heap.d
@@ -32,19 +32,23 @@ package:
 	}
 
 public:
-	bool isString() const {
+	@safe @nogc
+	bool isString() const pure nothrow {
 		return kind == Kind.String;
 	}
 
-	bool isArray() const {
+	@safe @nogc
+	bool isArray() const pure nothrow {
 		return kind == Kind.Array;
 	}
 
-	bool isObject() const {
+	@safe @nogc
+	bool isObject() const pure nothrow {
 		return kind == Kind.Object;
 	}
 
-	bool isMap() const {
+	@safe @nogc
+	bool isMap() const pure nothrow {
 		return kind == Kind.Map;
 	}
 }
@@ -106,19 +110,27 @@ package:
 	}
 
 package:
-	ref inout(VString) toVString() inout in(isString()) {
+	@trusted @nogc
+	ref inout(VString) toVString() inout nothrow pure return
+	in(isString()) {
 		return *(cast(inout(VString)*) &this);
 	}
 
-	ref inout(VArray) toVArray() inout in(isArray()) {
+	@trusted @nogc
+	ref inout(VArray) toVArray() inout nothrow pure return
+	in(isArray()) {
 		return *(cast(inout(VArray)*) &this);
 	}
 
-	ref inout(VObject) toVObject() inout in(isObject()) {
+	@trusted @nogc
+	ref inout(VObject) toVObject() inout nothrow pure return
+	in(isObject()) {
 		return *(cast(inout(VObject)*) &this);
 	}
 
-	ref inout(VMap) toVMap() inout in(isMap()) {
+	@trusted @nogc
+	ref inout(VMap) toVMap() inout nothrow pure return
+	in(isMap()) {
 		return *(cast(inout(VMap)*) &this);
 	}
 
@@ -133,8 +145,10 @@ package:
 		return dispatch!fun(this);
 	}
 
-	hash_t toHash() const {
-		static fun(T)(T x) {
+	@safe
+	size_t toHash() const nothrow {
+		@safe
+		static fun(T)(T x) nothrow {
 			return x.toHash();
 		}
 
@@ -368,12 +382,14 @@ public:
 		return rhs.isString() && rhs.toVString() == this;
 	}
 
-	hash_t toHash() const {
+	@safe
+	size_t toHash() const nothrow {
 		import config.hash;
 		return Hasher().hash(toString());
 	}
 
-	string toString() const {
+	@trusted
+	string toString() const nothrow {
 		auto ptr = cast(immutable char*) (impl + 1);
 		return ptr[0 .. tag.length];
 	}
@@ -501,7 +517,8 @@ public:
 		return rhs.isArray() && rhs.toVArray() == this;
 	}
 
-	hash_t toHash() const {
+	@safe
+	size_t toHash() const nothrow {
 		import config.hash;
 		return Hasher().hash(toArray());
 	}
@@ -511,7 +528,8 @@ public:
 		return format!"[%-(%s, %)]"(toArray().map!(v => v.dump()));
 	}
 
-	inout(Value)[] toArray() inout {
+	@trusted
+	inout(Value)[] toArray() inout nothrow {
 		auto ptr = cast(inout Value*) (impl + 1);
 		return ptr[0 .. tag.length];
 	}

--- a/src/config/value.d
+++ b/src/config/value.d
@@ -176,7 +176,8 @@ public:
 	/**
 	 * Values that lives on the heap.
 	 */
-	private bool isHeapValue() const {
+	@trusted
+	private bool isHeapValue() const nothrow {
 		if (heapValue is null) {
 			return false;
 		}
@@ -343,7 +344,7 @@ public:
 	}
 
 	@trusted
-	hash_t toHash() const {
+	hash_t toHash() const nothrow {
 		return isHeapValue() ? heapValue.toHash() : payload;
 	}
 

--- a/src/source/swar/util.d
+++ b/src/source/swar/util.d
@@ -1,5 +1,6 @@
 module source.swar.util;
 
+@trusted
 auto unalignedLoad(T)(string s) in(s.length >= T.sizeof) {
 	return *(cast(T*) s.ptr);
 }
@@ -17,6 +18,7 @@ auto read(T)(string s) {
 	return v;
 }
 
+@trusted
 auto unalignedLoad(T)(const(ubyte)[] data) in(data.length >= T.sizeof) {
 	return *(cast(T*) data.ptr);
 }


### PR DESCRIPTION
I removed heapValue from the VObjectKey union because it wasn't used and made it too difficult to prove safety.

Fixes build failures and CI failures such as these: https://github.com/snazzy-d/sdc/actions/runs/3970459790/jobs/6806208714