### PR TITLE
Allow warnings in builds.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,6 +9,7 @@
 			"targetType": "executable",
 			"targetPath": "bin",
 			"targetName": "sdfmt",
+			"buildRequirements": ["allowWarnings"],
 			"mainSourceFile": "src/driver/sdfmt.d",
 			"sourcePaths": [],
 			"dependencies": {
@@ -21,6 +22,7 @@
 			"targetType": "library",
 			"targetPath": "lib",
 			"targetName": "format",
+			"buildRequirements": ["allowWarnings"],
 			"sourcePaths": ["src/format/"],
 			"dependencies": {
 				"sdc:source": { "version": "*" }
@@ -31,6 +33,7 @@
 			"targetType": "library",
 			"targetPath": "lib",
 			"targetName": "config",
+			"buildRequirements": ["allowWarnings"],
 			"sourcePaths": ["src/config/"],
 			"dependencies": {
 				"sdc:source": { "version": "*" }
@@ -41,6 +44,7 @@
 			"targetType": "library",
 			"targetPath": "lib",
 			"targetName": "source",
+			"buildRequirements": ["allowWarnings"],
 			"sourcePaths": ["src/source/"],
 			"dependencies": {
 				"sdc:util": { "version": "*" }
@@ -51,6 +55,7 @@
 			"targetType": "library",
 			"targetPath": "lib",
 			"targetName": "util",
+			"buildRequirements": ["allowWarnings"],
 			"sourcePaths": ["src/util/"]
 		}
 	]

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ NASM ?= nasm
 RDMD ?= rdmd
 
 ARCHFLAG ?= -m64
-DFLAGS = $(ARCHFLAG) -Isrc -w -debug -g
+DFLAGS = $(ARCHFLAG) -Isrc -debug -g
 PLATFORM = $(shell uname -s)
 
 # DFLAGS = $(ARCHFLAG) -w -O -release


### PR DESCRIPTION
This will be reverted when the CI compiler can be advanced sufficiently that the warning is no longer present.

(There are no real warnings caused by sdc currently)