### PR TITLE
export_dynamic on macos

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ ifeq ($(PLATFORM),Linux)
 	override NASMFLAGS += -f elf64
 endif
 ifeq ($(PLATFORM),Darwin)
-	override LDFLAGS += -lc++
+	override LDFLAGS += -lc++ -Wl,-export_dynamic
 	override NASMFLAGS += -f macho64
 endif
 ifeq ($(PLATFORM),FreeBSD)


### PR DESCRIPTION
Same as on linux, otherwise the JIT can't find symbols in the current binary.