### PR TITLE
allocAppendable() and getCapacity().

### DIFF
--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -104,7 +104,7 @@ private:
 		Bitmap!512 _slabData;
 
 		// Metadata for non-slab (large) size classes
-		size_t allocSize; // Actual alloc size
+		size_t allocSize; // Actual alloc size, 0 if not appendable
 	}
 
 	Meta _meta;

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -104,7 +104,6 @@ private:
 		Bitmap!512 slabData;
 
 		// Metadata for non-slab (large) size classes:
-		// 0: not appendable; 1: appendable, empty; N>1: appendable, fill=N-1
 		size_t allocSize;
 	}
 
@@ -130,7 +129,7 @@ private:
 
 			slabData.clear();
 		} else {
-			_metadata.allocSize = 0;
+			_metadata.allocSize = size;
 		}
 	}
 
@@ -263,18 +262,19 @@ public:
 	}
 
 	bool isAppendable() {
-		return isLarge() && (_metadata.allocSize != 0);
+		// Currently, all large (and only large) allocs are appendable
+		return isLarge();
 	}
 
 	@property
 	ulong allocSize() {
 		assert(isAppendable(), "Cannot get alloc size on non-appendable!");
-		return _metadata.allocSize - 1;
+		return _metadata.allocSize;
 	}
 
 	void setAllocSize(size_t size) {
 		assert(isLarge(), "Cannot set alloc size on a slab alloc!");
-		_metadata.allocSize = size + 1;
+		_metadata.allocSize = size;
 	}
 }
 

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -136,7 +136,7 @@ private:
 public:
 	@property
 	bool isAppendable() {
-		return isLarge() && allocSize;
+		return allocSize != 0;
 	}
 
 	@property

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -100,11 +100,11 @@ private:
 
 	import d.gc.bitmap;
 	union MetaData {
-		// Slab occupancy (constrained by freeSlots, so usable for all classes)
+		// Slab occupancy (constrained by freeSlots, so usable for all classes).
 		Bitmap!512 slabData;
 
-		// Metadata for non-slab (large) size classes:
-		size_t allocSize;
+		// Metadata for large extents.
+		size_t usedCapacity;
 	}
 
 	MetaData _metadata;
@@ -129,7 +129,7 @@ private:
 
 			slabData.clear();
 		} else {
-			_metadata.allocSize = 0;
+			setUsedCapacity(size);
 		}
 	}
 
@@ -256,25 +256,19 @@ public:
 	/**
 	 * Large features.
 	 */
-
 	bool isLarge() const {
 		return !isSlab();
 	}
 
-	bool isAppendable() {
-		// Currently, all large (and only large) allocs are appendable
-		return isLarge();
-	}
-
 	@property
-	ulong allocSize() {
-		assert(isAppendable(), "Cannot get alloc size on non-appendable!");
-		return _metadata.allocSize;
+	ulong usedCapacity() {
+		assert(isLarge(), "usedCapacity accessed on non large!");
+		return _metadata.usedCapacity;
 	}
 
-	void setAllocSize(size_t size) {
-		assert(isLarge(), "Cannot set alloc size on a slab alloc!");
-		_metadata.allocSize = size;
+	void setUsedCapacity(size_t size) {
+		assert(isLarge(), "Cannot set used capacity on a slab alloc!");
+		_metadata.usedCapacity = size;
 	}
 }
 

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -129,7 +129,7 @@ private:
 
 			slabData.clear();
 		} else {
-			_metadata.allocSize = size;
+			_metadata.allocSize = 0;
 		}
 	}
 

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -136,7 +136,7 @@ private:
 public:
 	@property
 	bool isAppendable() {
-		return (!isSlab() && allocSize != 0);
+		return allocSize != 0;
 	}
 
 	@property

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -104,7 +104,7 @@ private:
 		Bitmap!512 slabData;
 
 		// Metadata for non-slab (large) size classes:
-		// Actual alloc size, 0 if not appendable, 1 -- empty, N: contains N-1
+		// 0: not appendable; 1: appendable, empty; N>1: appendable, fill=N-1
 		size_t allocSize;
 	}
 

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -136,15 +136,16 @@ private:
 public:
 	@property
 	bool isAppendable() {
-		return allocSize != 0;
+		return isLarge() && allocSize;
 	}
 
 	@property
 	ulong allocSize() {
-		return isSlab() ? 0 : _meta.allocSize;
+		return isLarge() ? _meta.allocSize : 0;
 	}
 
 	void setAllocSize(size_t size) {
+		assert(isLarge(), "Cannot set alloc size on a slab alloc!");
 		_meta.allocSize = size;
 	}
 
@@ -224,6 +225,10 @@ public:
 	bool isSlab() const {
 		auto ec = extentClass;
 		return ec.isSlab();
+	}
+
+	bool isLarge() const {
+		return !isSlab();
 	}
 
 	@property

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -104,7 +104,7 @@ private:
 		Bitmap!512 slabData;
 
 		// Metadata for non-slab (large) size classes:
-		// Actual alloc size, 0 if not appendable
+		// Actual alloc size, 0 if not appendable, 1 -- empty, N: contains N-1
 		size_t allocSize;
 	}
 
@@ -262,19 +262,19 @@ public:
 		return !isSlab();
 	}
 
-	@property
 	bool isAppendable() {
-		return allocSize != 0;
+		return isLarge() && (_metadata.allocSize != 0);
 	}
 
 	@property
 	ulong allocSize() {
-		return isLarge() ? _metadata.allocSize : 0;
+		assert(isAppendable(), "Cannot get alloc size on non-appendable!");
+		return _metadata.allocSize - 1;
 	}
 
 	void setAllocSize(size_t size) {
 		assert(isLarge(), "Cannot set alloc size on a slab alloc!");
-		_metadata.allocSize = size;
+		_metadata.allocSize = size + 1;
 	}
 }
 

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -104,7 +104,7 @@ private:
 		Bitmap!512 _slabData;
 
 		// Metadata for non-slab (large) size classes
-		ulong allocSize; // Actual alloc size
+		size_t allocSize; // Actual alloc size
 	}
 
 	Meta _meta;
@@ -140,8 +140,8 @@ public:
 	}
 
 	@property
-	ref ulong allocSize() {
-		return _meta.allocSize;
+	ulong allocSize() {
+		return isSlab() ? 0 : _meta.allocSize;
 	}
 
 	void setAllocSize(size_t size) {

--- a/sdlib/d/gc/sizeclass.d
+++ b/sdlib/d/gc/sizeclass.d
@@ -43,6 +43,7 @@ enum ClassCount {
 enum SizeClass {
 	Tiny = getSizeFromClass(ClassCount.Tiny - 1),
 	Small = getSizeFromClass(ClassCount.Small - 1),
+	Large = getSizeFromClass(ClassCount.Small),
 }
 
 enum MaxTinySize = ClassCount.Tiny * Quantum;

--- a/sdlib/d/gc/sizeclass.d
+++ b/sdlib/d/gc/sizeclass.d
@@ -43,7 +43,6 @@ enum ClassCount {
 enum SizeClass {
 	Tiny = getSizeFromClass(ClassCount.Tiny - 1),
 	Small = getSizeFromClass(ClassCount.Small - 1),
-	Large = getSizeFromClass(ClassCount.Small),
 }
 
 enum MaxTinySize = ClassCount.Tiny * Quantum;

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -116,7 +116,10 @@ public:
 				|| ((pdRight.extent !is null) && (pdRight.containsPointers));
 			// Allocate a new appendable block:
 			appended = alloc(lBytes + rBytes, hasPointers, true);
-			// ... and copy the left slice to it:
+			// OOM?
+			if (appended is null)
+				return null;
+			// Copy the left slice:
 			memcpy(appended, lAddr, lBytes);
 		}
 
@@ -372,9 +375,15 @@ unittest appendableAlloc {
 	int[] b = [11, 12, 13];
 	int[] c = [14, 15, 16];
 
+	assert(!threadCache.getArrayCapacity(a.ptr, a.length * int.sizeof));
+	assert(!threadCache.getArrayCapacity(b.ptr, b.length * int.sizeof));
+	assert(!threadCache.getArrayCapacity(c.ptr, c.length * int.sizeof));
+
 	// a ~= b :
 	auto _ab = threadCache.appendArray(a.ptr, int.sizeof * a.length, b.ptr,
 	                                   int.sizeof * b.length);
+	assert(_ab !is null);
+	assert(_ab !is cast(void*) a.ptr);
 	int[] ab = cast(int[]) _ab[0 .. a.length + b.length];
 
 	assert(threadCache.getArrayCapacity(ab.ptr, int.sizeof * ab.length));

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -405,4 +405,14 @@ unittest appendableAlloc {
 	// Realloc prohibited by appendable fill, so nothing should change
 	auto p3 = threadCache.realloc(p0, 40000, false);
 	assert(p3 == p0);
+
+	threadCache.free(p0);
+	threadCache.free(p1);
+
+	// Pointer the GC does not know about:
+	auto martian = cast(void*) 0x56789abcd000;
+	assert(!threadCache.is_appendable(martian));
+	assert(threadCache.set_appendable_fill(martian, 333) == false);
+	assert(threadCache.get_appendable_fill(martian) == 0);
+	assert(threadCache.get_appendable_free_space(martian) == 0);
 }

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -162,14 +162,14 @@ public:
 
 			// TODO: Try to extend/shrink in place.
 			if (appendable) {
-				// Prohibit resize below appendable fill, if one exists:
+				// Prohibit resize below appendable fill:
 				if (size < pd.extent.allocSize)
 					return ptr;
 				copySize = pd.extent.allocSize;
 				allocateSize = copySize;
 				// If enlarging an appendable, boost spare capacity:
 				if (esize < size)
-					spareCapacity = esize * 2;
+					spareCapacity = max(size, esize * 2);
 			} else {
 				copySize = min(size, esize);
 			}

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -79,23 +79,21 @@ public:
 	//
 	//   ______data_____  ___free space___
 	//  /               \/                \
-	//  -----------------------------------
 	// |X|X|X|X|X|S|S|S|S|.|.|.|.|.|.|.|.|.|
-	//  -----------------------------------
 	//           \________________________/
 	// 	         Capacity of segment S is 13
 	//
 	// No free space above S, capacity(S) is 0:
-	//  -----------------------------------
 	// |S|S|S|S|X|X|X|X|X|.|.|.|.|.|.|.|.|.|
-	//  -----------------------------------
+	//
 	// Similarly:
-	//  -----------------------------------
 	// |X|X|X|X|S|S|S|S|X|.|.|.|.|.|.|.|.|.|
-	//  -----------------------------------
 
 	// Get the append capacity of a segment denoted by ptr and len,
 	// i.e. the max length that segment can grow to without a reallocation.
+	// Segments without free space immediately above them have capacity of 0.
+	// Note that a segment of length 0 can have a capacity > 0 if there is
+	// no data in the block.
 	// See also: https://dlang.org/spec/arrays.html#capacity-reserve
 	size_t getCapacity(void* ptr, size_t len) {
 		auto pd = maybeGetPageDescriptor(ptr);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -130,10 +130,9 @@ public:
 			if (size < oldFill)
 				return ptr;
 
-			auto oldSize =
-				oldFill ? alignUp(oldFill, PageSize) : pd.extent.size;
+			auto oldSize = oldFill ? oldFill : pd.extent.size;
 
-			if (alignUp(size, PageSize) == oldSize) {
+			if (alignUp(size, PageSize) == alignUp(oldSize, PageSize)) {
 				return ptr;
 			}
 

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -95,7 +95,7 @@ public:
 		if (segEnd < pd.extent.allocSize)
 			return 0;
 
-		// Otherwise, capacity is length of segment and of free space above it:
+		// Otherwise, return length of segment and the free space above it:
 		return pd.extent.size - segStart;
 	}
 
@@ -406,4 +406,8 @@ unittest appendableAlloc {
 
 	threadCache.free(p0);
 	threadCache.free(p2);
+
+	// Capacity of any segment in space unknown to the GC is zero:
+	int[] a = [1, 2, 3];
+	assert(threadCache.getCapacity(a.ptr, int.sizeof * a.length) == 0);
 }

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -75,6 +75,25 @@ public:
 	 * Appendables API.
 	 */
 
+	// Appendable Capacity:
+	//
+	//   ______data_____  ___free space___
+	//  /               \/                \
+	//  -----------------------------------
+	// |X|X|X|X|X|S|S|S|S|.|.|.|.|.|.|.|.|.|
+	//  -----------------------------------
+	//           \________________________/
+	// 	         Capacity of segment S is 13
+	//
+	// No free space above S, capacity(S) is 0:
+	//  -----------------------------------
+	// |S|S|S|S|X|X|X|X|X|.|.|.|.|.|.|.|.|.|
+	//  -----------------------------------
+	// Similarly:
+	//  -----------------------------------
+	// |X|X|X|X|S|S|S|S|X|.|.|.|.|.|.|.|.|.|
+	//  -----------------------------------
+
 	// Get the append capacity of a segment denoted by ptr and len,
 	// i.e. the max length that segment can grow to without a reallocation.
 	// See also: https://dlang.org/spec/arrays.html#capacity-reserve

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -101,7 +101,7 @@ public:
 		// If appending in place, use lAddr for result:
 		void* appended = lAddr;
 
-		auto pdLeft = getPageDescriptor(lAddr);
+		auto pdLeft = maybeGetPageDescriptor(lAddr);
 
 		if (inPlace) {
 			// Knowing that left slice is appendable, set its block's fill:
@@ -110,7 +110,7 @@ public:
 		} else {
 			// If either left or right slice is know to GC and contains pointers,
 			// the result will therefore also contain pointers:
-			auto pdRight = getPageDescriptor(rAddr);
+			auto pdRight = maybeGetPageDescriptor(rAddr);
 			bool hasPointers = ((pdLeft.extent !is null)
 					&& (pdLeft.containsPointers))
 				|| ((pdRight.extent !is null) && (pdRight.containsPointers));

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -308,20 +308,6 @@ size_t upsizeToLarge(size_t size) {
 	return getAllocSize(size) <= SizeClass.Small ? SizeClass.Large : size;
 }
 
-bool isAllocatableSize(size_t size) {
-	return size > 0 && size <= MaxAllocationSize;
-}
-
-unittest isAllocatableSize {
-	assert(!isAllocatableSize(0));
-	assert(isAllocatableSize(1));
-	assert(isAllocatableSize(42));
-	assert(isAllocatableSize(99999));
-	assert(isAllocatableSize(MaxAllocationSize));
-	assert(!isAllocatableSize(MaxAllocationSize + 1));
-	assert(!isAllocatableSize(size_t.max));
-}
-
 extern(C):
 version(OSX) {
 	// For some reason OSX's symbol get a _ prepended.

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -83,6 +83,9 @@ public:
 	//           \________________________/
 	// 	       Capacity of segment S is 13
 	//
+	// Similarly:
+	// |X|X|X|X|X|S|S|S|S|S|S|S|S|S|S|S|S|S|
+	//
 	// No free space next to S, so capacity(S) is 0:
 	// |S|S|S|S|X|X|X|X|X|.|.|.|.|.|.|.|.|.|
 	//
@@ -112,7 +115,7 @@ public:
 		if (segEnd < pd.extent.allocSize)
 			return 0;
 
-		// Otherwise, return length of segment and the free space above it:
+		// Otherwise, return length of segment plus any free space above it:
 		return pd.extent.size - segStart;
 	}
 

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -388,6 +388,7 @@ unittest appendableAlloc {
 	assert(!threadCache.is_appendable(p1));
 	assert(threadCache.get_appendable_fill(p1) == 0);
 	assert(threadCache.get_appendable_free_space(p1) == 0);
+	threadCache.free(p1);
 
 	// Realloc an appendable alloc up :
 	p0 = threadCache.realloc(p0, 100000, false);
@@ -406,10 +407,13 @@ unittest appendableAlloc {
 	auto p3 = threadCache.realloc(p0, 40000, false);
 	assert(p3 == p0);
 
+	// Pointers the GC does not know about:
+	void* interior = p0 + 2000;
+	assert(!threadCache.is_appendable(interior));
+	assert(threadCache.set_appendable_fill(interior, 222) == false);
+	assert(threadCache.get_appendable_fill(interior) == 0);
+	assert(threadCache.get_appendable_free_space(interior) == 0);
 	threadCache.free(p0);
-	threadCache.free(p1);
-
-	// Pointer the GC does not know about:
 	auto martian = cast(void*) 0x56789abcd000;
 	assert(!threadCache.is_appendable(martian));
 	assert(threadCache.set_appendable_fill(martian, 333) == false);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -155,9 +155,9 @@ public:
 		}
 
 		containsPointers = (containsPointers | pd.containsPointers) != 0;
-		auto allocSize = appendable ? copySize : size;
+		auto useSize = appendable ? copySize : size;
 		auto newPtr =
-			alloc(allocSize, containsPointers, appendable, spareCapacity);
+			alloc(useSize, containsPointers, appendable, spareCapacity);
 		if (newPtr is null) {
 			return null;
 		}

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -389,8 +389,8 @@ unittest appendableAlloc {
 
 	// This realloc will have no effect, as the requested size
 	// is below the appendable fill size:
-	p0 = threadCache.realloc(p0, 99, false);
-	assert(threadCache.getCapacity(p0, 100) == 16384);
+	auto p3 = threadCache.realloc(p0, 99, false);
+	assert(p3 == p0);
 
 	// Enlarging the spare capacity :
 	p0 = threadCache.realloc(p0, 16385, false);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -75,25 +75,25 @@ public:
 	 * Appendables API.
 	 */
 
-	// Appendable Capacity:
+	// Mechanics of Appendable Capacity:
 	//
 	//   ______data_____  ___free space___
 	//  /               \/                \
 	// |X|X|X|X|X|S|S|S|S|.|.|.|.|.|.|.|.|.|
 	//           \________________________/
-	// 	         Capacity of segment S is 13
+	// 	       Capacity of segment S is 13
 	//
-	// No free space above S, capacity(S) is 0:
+	// No free space next to S, so capacity(S) is 0:
 	// |S|S|S|S|X|X|X|X|X|.|.|.|.|.|.|.|.|.|
 	//
 	// Similarly:
 	// |X|X|X|X|S|S|S|S|X|.|.|.|.|.|.|.|.|.|
 
-	// Get the append capacity of a segment denoted by ptr and len,
+	// Get the appendable capacity of a segment denoted by ptr and len,
 	// i.e. the max length that segment can grow to without a reallocation.
 	// Segments without free space immediately above them have capacity of 0.
-	// Note that a segment of length 0 can have a capacity > 0 if there is
-	// no data in the block.
+	// Note that a segment of length 0 starting from the bottom of a block can
+	// have a capacity > 0 if there is no data in the block.
 	// See also: https://dlang.org/spec/arrays.html#capacity-reserve
 	size_t getCapacity(void* ptr, size_t len) {
 		auto pd = maybeGetPageDescriptor(ptr);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -64,6 +64,10 @@ public:
 		pd.arena.free(emap, pd, ptr);
 	}
 
+	/**
+	 * Appendables API.
+	 */
+
 	// Determine whether given alloc is appendable
 	bool is_appendable(void* ptr) {
 		return maybeGetAppendableExtent(ptr) !is null;
@@ -97,6 +101,10 @@ public:
 		return false;
 	}
 
+	/**
+	 * Reallocation.
+	 */
+
 	void* realloc(void* ptr, size_t size, bool containsPointers) {
 		if (!isAllocatableSize(size)) {
 			free(ptr);
@@ -110,8 +118,6 @@ public:
 		size_t oldFill = 0;
 		auto copySize = size;
 		auto pd = getPageDescriptor(ptr);
-
-		// TODO: should realloc work with pointers outside of GC?
 
 		if (pd.isSlab()) {
 			auto newSizeClass = getSizeClass(size);
@@ -231,16 +237,6 @@ public:
 	}
 
 private:
-	// Force large allocation rather than slab
-	size_t upsizeToLarge(size_t size) {
-		auto aSize = size;
-		while (getAllocSize(aSize) <= SizeClass.Small) {
-			aSize = getSizeFromClass(getSizeClass(aSize) + 1);
-		}
-
-		return aSize;
-	}
-
 	// Get appendable extent of ptr, or null if this is impossible
 	Extent* maybeGetAppendableExtent(void* ptr) {
 		if (ptr is null)
@@ -293,6 +289,11 @@ private:
 }
 
 private:
+
+// Force large allocation rather than slab
+size_t upsizeToLarge(size_t size) {
+	return getAllocSize(size) <= SizeClass.Small ? SizeClass.Large : size;
+}
 
 bool isAllocatableSize(size_t size) {
 	return size > 0 && size <= MaxAllocationSize;

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -115,7 +115,7 @@ public:
 
 		// Whether old (and therefore new) block is appendable:
 		bool appendable = false;
-		// Spare capacity for enlarging a reallocatable block:
+		// Spare capacity for enlarging appendable block:
 		size_t spareCapacity = 0;
 		auto copySize = size;
 		auto pd = getPageDescriptor(ptr);


### PR DESCRIPTION
- Appendability metadata, currently for large-sized allocs only. All large allocs are now considered appendable.
- `allocAppendable()`: requests an appendable block of given size and saves the used capacity in the extent metadata.
- `getCapacity()`: computes the capacity of a memory segment per the rules of https://dlang.org/spec/arrays.html#capacity-reserve .
- `realloc()`: modified to behave correctly on appendable allocs.
- Tests.