### PR TITLE
extend()

### DIFF
--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -198,12 +198,13 @@ public:
 		}
 
 		// There must be sufficient free space to extend into:
-		if (pd.extent.size - stopIndex < length) {
+		auto newCapacity = stopIndex + length;
+		if (pd.extent.size < newCapacity) {
 			return false;
 		}
 
 		// Increase the used capacity by the requested length:
-		pd.extent.setUsedCapacity(pd.extent.usedCapacity + length);
+		pd.extent.setUsedCapacity(newCapacity);
 
 		return true;
 	}

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -457,20 +457,36 @@ unittest extend {
 	// Attempt to extend a non-appendable:
 	assert(!threadCache.extend(nonAppendable[0 .. 100], 1));
 
+	// Extend by zero is permitted even when no capacity:
+	assert(threadCache.extend(nonAppendable[0 .. 100], 0));
+
+	// Extend in space unknown to the GC. Can only extend by zero.
+	void* nullPtr = null;
+	assert(threadCache.extend(nullPtr[0 .. 100], 0));
+	assert(!threadCache.extend(nullPtr[0 .. 100], 1));
+	assert(!threadCache.extend(nullPtr[100 .. 100], 1));
+
+	void* stackPtr = &nullPtr;
+	assert(threadCache.extend(stackPtr[0 .. 100], 0));
+	assert(!threadCache.extend(stackPtr[0 .. 100], 1));
+	assert(!threadCache.extend(stackPtr[100 .. 100], 1));
+
+	void* tlPtr = &threadCache;
+	assert(threadCache.extend(tlPtr[0 .. 100], 0));
+	assert(!threadCache.extend(tlPtr[0 .. 100], 1));
+	assert(!threadCache.extend(tlPtr[100 .. 100], 1));
+
 	// Make an appendable alloc:
 	auto p0 = threadCache.allocAppendable(100, false);
 	assert(threadCache.getCapacity(p0[0 .. 100]) == 16384);
 
-	// Attempt to extend slices with capacity 0:
+	// Attempt to extend valid slices with capacity 0.
+	// (See getCapacity tests.)
 	assert(threadCache.extend(p0[0 .. 0], 0));
 	assert(!threadCache.extend(p0[0 .. 0], 50));
 	assert(!threadCache.extend(p0[0 .. 99], 50));
 	assert(!threadCache.extend(p0[1 .. 99], 50));
 	assert(!threadCache.extend(p0[0 .. 50], 50));
-
-	// Attempt extend with insufficient space:
-	assert(!threadCache.extend(p0[0 .. 100], 16285));
-	assert(!threadCache.extend(p0[50 .. 100], 16285));
 
 	// Extend by size zero is permitted but has no effect:
 	assert(threadCache.extend(p0[100 .. 100], 0));
@@ -479,65 +495,71 @@ unittest extend {
 	assert(threadCache.extend(p0[50 .. 100], 0));
 	assert(threadCache.getCapacity(p0[50 .. 100]) == 16334);
 
-	// Extend by zero is permitted even when no capacity:
-	assert(threadCache.extend(nonAppendable[0 .. 100], 0));
+	// Attempt extend with insufficient space (one byte too many) :
+	assert(threadCache.getCapacity(p0[100 .. 100]) == 16284);
+	assert(!threadCache.extend(p0[0 .. 100], 16285));
+	assert(!threadCache.extend(p0[50 .. 100], 16285));
 
-	void* nullPtr = null;
-	assert(threadCache.extend(nullPtr[0 .. 100], 0));
+	// Extending to the limit (one less than above) succeeds:
+	assert(threadCache.extend(p0[50 .. 100], 16284));
 
-	void* stackPtr = &nullPtr;
-	assert(threadCache.extend(stackPtr[0 .. 100], 0));
+	// Now we're full, and can extend only by zero:
+	assert(threadCache.extend(p0[0 .. 16384], 0));
 
-	void* tlPtr = &threadCache;
-	assert(threadCache.extend(tlPtr[0 .. 100], 0));
+	// Make another appendable alloc:
+	auto p1 = threadCache.allocAppendable(100, false);
+	assert(threadCache.getCapacity(p1[0 .. 100]) == 16384);
 
 	// Valid extend :
-	assert(threadCache.extend(p0[0 .. 100], 50));
-	assert(threadCache.getCapacity(p0[100 .. 150]) == 16284);
+	assert(threadCache.extend(p1[0 .. 100], 50));
+	assert(threadCache.getCapacity(p1[100 .. 150]) == 16284);
+	assert(threadCache.extend(p1[0 .. 150], 0));
 
 	// Capacity of old slice becomes 0:
-	assert(threadCache.getCapacity(p0[0 .. 100]) == 0);
+	assert(threadCache.getCapacity(p1[0 .. 100]) == 0);
 
 	// The only permitted extend is by 0:
-	assert(threadCache.extend(p0[0 .. 100], 0));
+	assert(threadCache.extend(p1[0 .. 100], 0));
 
 	// Capacity of a slice including the original and the extension:
-	assert(threadCache.getCapacity(p0[0 .. 150]) == 16384);
+	assert(threadCache.getCapacity(p1[0 .. 150]) == 16384);
 
 	// Extend the upper half:
-	assert(threadCache.extend(p0[125 .. 150], 100));
-	assert(threadCache.getCapacity(p0[150 .. 250]) == 16234);
+	assert(threadCache.extend(p1[125 .. 150], 100));
+	assert(threadCache.getCapacity(p1[150 .. 250]) == 16234);
 
 	// Original's capacity becomes 0:
-	assert(threadCache.getCapacity(p0[125 .. 150]) == 0);
+	assert(threadCache.getCapacity(p1[125 .. 150]) == 0);
+	assert(threadCache.extend(p1[125 .. 150], 0));
 
 	// Capacity of a slice including original and extended:
-	assert(threadCache.getCapacity(p0[125 .. 250]) == 16259);
+	assert(threadCache.extend(p1[125 .. 250], 0));
+	assert(threadCache.getCapacity(p1[125 .. 250]) == 16259);
 
 	// Capacity of earlier slice elongated to cover the extensions :
-	assert(threadCache.getCapacity(p0[0 .. 250]) == 16384);
+	assert(threadCache.getCapacity(p1[0 .. 250]) == 16384);
 
 	// Extend a zero-size slice existing at the start of the free space:
-	assert(threadCache.extend(p0[250 .. 250], 200));
-	assert(threadCache.getCapacity(p0[250 .. 450]) == 16134);
+	assert(threadCache.extend(p1[250 .. 250], 200));
+	assert(threadCache.getCapacity(p1[250 .. 450]) == 16134);
 
 	// Capacity of the old slice is now 0:
-	assert(threadCache.getCapacity(p0[0 .. 250]) == 0);
+	assert(threadCache.getCapacity(p1[0 .. 250]) == 0);
 
 	// Capacity of a slice which includes the original and the extension:
-	assert(threadCache.getCapacity(p0[0 .. 450]) == 16384);
+	assert(threadCache.getCapacity(p1[0 .. 450]) == 16384);
 
 	// Extend so as to fill up all but one byte of free space:
-	assert(threadCache.extend(p0[0 .. 450], 15933));
-	assert(threadCache.getCapacity(p0[16383 .. 16383]) == 1);
+	assert(threadCache.extend(p1[0 .. 450], 15933));
+	assert(threadCache.getCapacity(p1[16383 .. 16383]) == 1);
 
 	// Extend, filling up last byte of free space:
-	assert(threadCache.extend(p0[16383 .. 16383], 1));
-	assert(threadCache.getCapacity(p0[0 .. 16384]) == 16384);
+	assert(threadCache.extend(p1[16383 .. 16383], 1));
+	assert(threadCache.getCapacity(p1[0 .. 16384]) == 16384);
 
 	// Attempt to extend, but we're full:
-	assert(!threadCache.extend(p0[0 .. 16384], 1));
+	assert(!threadCache.extend(p1[0 .. 16384], 1));
 
 	// Extend by size zero still works, though:
-	assert(threadCache.extend(p0[0 .. 16384], 0));
+	assert(threadCache.extend(p1[0 .. 16384], 0));
 }

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -173,19 +173,21 @@ public:
 		return pd.extent.size - startIndex;
 	}
 
-	void* append(const void[] slice, size_t length) {
-		if (!isAllocatableSize(length))
+	void* extend(const void[] slice, size_t length) {
+		if (length == 0) {
 			return null;
+		}
 
-		// There must be sufficient free space to append into:
-		if (getCapacity(slice) < slice.length + length)
+		// There must be sufficient free space to extend into:
+		if (getCapacity(slice) < slice.length + length) {
 			return null;
+		}
 
 		// Increase the used capacity by the requested length:
 		auto pd = maybeGetPageDescriptor(slice.ptr);
 		pd.extent.setUsedCapacity(pd.extent.usedCapacity + length);
 
-		// Return pointer to the appended space:
+		// Return pointer to the extended space:
 		return cast(void*) slice.ptr + slice.length;
 	}
 
@@ -438,72 +440,71 @@ unittest getCapacity {
 	assert(threadCache.getCapacity(p5[0 .. 16000]) == 20480);
 }
 
-unittest Append {
-	// Append.
+unittest Extend {
 	auto nonAppendable = threadCache.alloc(100, false);
 
-	// Attempt to append a non-appendable:
-	assert(threadCache.append(nonAppendable[0 .. 100], 1) is null);
+	// Attempt to extend a non-appendable:
+	assert(threadCache.extend(nonAppendable[0 .. 100], 1) is null);
 
 	// Make an appendable alloc:
 	auto p0 = threadCache.allocAppendable(100, false);
 	assert(threadCache.getCapacity(p0[0 .. 100]) == 16384);
 
-	// Attempt append to slices with capacity 0:
-	assert(threadCache.append(p0[0 .. 0], 50) is null);
-	assert(threadCache.append(p0[0 .. 99], 50) is null);
-	assert(threadCache.append(p0[1 .. 99], 50) is null);
-	assert(threadCache.append(p0[0 .. 50], 50) is null);
+	// Attempt to extend slices with capacity 0:
+	assert(threadCache.extend(p0[0 .. 0], 50) is null);
+	assert(threadCache.extend(p0[0 .. 99], 50) is null);
+	assert(threadCache.extend(p0[1 .. 99], 50) is null);
+	assert(threadCache.extend(p0[0 .. 50], 50) is null);
 
-	// Attempt append with non-allocatable length:
-	assert(threadCache.append(p0[0 .. 100], 0) is null);
+	// Attempt extend with non-allocatable length:
+	assert(threadCache.extend(p0[0 .. 100], 0) is null);
 
-	// Attempt append with insufficient space:
-	assert(threadCache.append(p0[0 .. 100], 16285) is null);
-	assert(threadCache.append(p0[50 .. 100], 16285) is null);
+	// Attempt extend with insufficient space:
+	assert(threadCache.extend(p0[0 .. 100], 16285) is null);
+	assert(threadCache.extend(p0[50 .. 100], 16285) is null);
 
-	// Valid append :
-	auto p3 = threadCache.append(p0[0 .. 100], 50);
+	// Valid extend :
+	auto p3 = threadCache.extend(p0[0 .. 100], 50);
 	assert(p3 == p0 + 100);
 	assert(threadCache.getCapacity(p3[0 .. 50]) == 16284);
 
 	// Capacity of old slice becomes 0, as there is now data in front of it:
 	assert(threadCache.getCapacity(p0[0 .. 100]) == 0);
 
-	// Capacity of a slice including the original and the append:
+	// Capacity of a slice including the original and the extension:
 	assert(threadCache.getCapacity(p0[0 .. 150]) == 16384);
 
-	// Append the upper half of p3:
-	auto p4 = threadCache.append(p3[25 .. 50], 100);
+	// Extend the upper half of p3:
+	auto p4 = threadCache.extend(p3[25 .. 50], 100);
 	assert(threadCache.getCapacity(p4[0 .. 100]) == 16234);
 
 	// Original's capacity becomes 0:
 	assert(threadCache.getCapacity(p3[25 .. 50]) == 0);
 
-	// Capacity of a slice including original and appended:
+	// Capacity of a slice including original and extended:
 	assert(threadCache.getCapacity(p3[25 .. 150]) == 16259);
 
-	// Capacity of earlier slice elongated to cover the appends :
+	// Capacity of earlier slice elongated to cover the extensions :
 	assert(threadCache.getCapacity(p0[0 .. 250]) == 16384);
 
-	// Append a zero-length slice existing at the start of the free space:
-	auto p5 = threadCache.append(p0[250 .. 250], 200);
+	// Extend a zero-length slice existing at the start of the free space:
+	auto p5 = threadCache.extend(p0[250 .. 250], 200);
 	assert(threadCache.getCapacity(p5[0 .. 200]) == 16134);
 
 	// Capacity of the old slice is now 0:
 	assert(threadCache.getCapacity(p0[0 .. 250]) == 0);
 
-	// Capacity of a slice which includes the original and the append:
+	// Capacity of a slice which includes the original and the extension:
 	assert(threadCache.getCapacity(p0[0 .. 450]) == 16384);
 
-	// Append so as to fill up all but one byte of free space:
-	auto p6 = threadCache.append(p0[0 .. 450], 15933);
+	// Extend so as to fill up all but one byte of free space:
+	auto p6 = threadCache.extend(p0[0 .. 450], 15933);
 	assert(threadCache.getCapacity(p0[16383 .. 16383]) == 1);
 
-	// Append, filling up last byte of free space:
-	auto p7 = threadCache.append(p0[16383 .. 16383], 1);
+	// Extend, filling up last byte of free space:
+	auto p7 = threadCache.extend(p0[16383 .. 16383], 1);
 	assert(threadCache.getCapacity(p0[0 .. 16384]) == 16384);
 
-	// Attempt to append, but we're full:
-	assert(threadCache.append(p0[0 .. 16384], 1) == null);
+	// Attempt to extend, but we're full:
+	assert(threadCache.extend(p0[0 .. 16384], 1) == null);
 }

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -456,8 +456,8 @@ unittest getCapacity {
 	assert(threadCache.append(p6[0 .. 100], 0) is null);
 
 	// Attempt append with insufficient space:
-	assert(threadCache.append(p6[0 .. 100], 16385) is null);
-	assert(threadCache.append(p6[50 .. 100], 16335) is null);
+	assert(threadCache.append(p6[0 .. 100], 16285) is null);
+	assert(threadCache.append(p6[50 .. 100], 16285) is null);
 
 	// Valid append :
 	auto p7 = threadCache.append(p6[0 .. 100], 50);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -531,7 +531,7 @@ unittest extend {
 	assert(threadCache.extend(p0[0 .. 450], 15933));
 	assert(threadCache.getCapacity(p0[16383 .. 16383]) == 1);
 
-	// // Extend, filling up last byte of free space:
+	// Extend, filling up last byte of free space:
 	assert(threadCache.extend(p0[16383 .. 16383], 1));
 	assert(threadCache.getCapacity(p0[0 .. 16384]) == 16384);
 

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -505,6 +505,7 @@ unittest extend {
 
 	// Now we're full, and can extend only by zero:
 	assert(threadCache.extend(p0[0 .. 16384], 0));
+	assert(!threadCache.extend(p0[0 .. 16384], 1));
 
 	// Make another appendable alloc:
 	auto p1 = threadCache.allocAppendable(100, false);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -439,7 +439,7 @@ unittest getCapacity {
 	assert(threadCache.getCapacity(p5[0 .. 16000]) == 20480);
 }
 
-unittest Extend {
+unittest extend {
 	auto nonAppendable = threadCache.alloc(100, false);
 
 	// Attempt to extend a non-appendable:

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -472,7 +472,7 @@ unittest extend {
 	assert(!threadCache.extend(p0[0 .. 100], 16285));
 	assert(!threadCache.extend(p0[50 .. 100], 16285));
 
-	// Extend by length zero is permitted if capacity>0, but has no effect:
+	// Extend by size zero is permitted if capacity>0, but has no effect:
 	assert(threadCache.extend(p0[100 .. 100], 0));
 	assert(threadCache.extend(p0[0 .. 100], 0));
 	assert(threadCache.getCapacity(p0[0 .. 100]) == 16384);
@@ -506,7 +506,7 @@ unittest extend {
 	// Capacity of earlier slice elongated to cover the extensions :
 	assert(threadCache.getCapacity(p0[0 .. 250]) == 16384);
 
-	// Extend a zero-length slice existing at the start of the free space:
+	// Extend a zero-size slice existing at the start of the free space:
 	assert(threadCache.extend(p0[250 .. 250], 200));
 	assert(threadCache.getCapacity(p0[250 .. 450]) == 16134);
 
@@ -527,6 +527,6 @@ unittest extend {
 	// Attempt to extend, but we're full:
 	assert(!threadCache.extend(p0[0 .. 16384], 1));
 
-	// Extend by length zero still works, though:
+	// Extend by size zero still works, though:
 	assert(threadCache.extend(p0[0 .. 16384], 0));
 }

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -177,13 +177,8 @@ public:
 		if (!isAllocatableSize(length))
 			return null;
 
-		auto capacity = getCapacity(slice);
-		if (capacity == 0)
-			return null;
-
 		// There must be sufficient free space to append into:
-		auto freeSpace = capacity - slice.length;
-		if (freeSpace < length)
+		if (getCapacity(slice) < slice.length + length)
 			return null;
 
 		// Increase the used capacity by the requested length:

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -198,8 +198,7 @@ public:
 		}
 
 		// There must be sufficient free space to extend into:
-		auto capacity = pd.extent.size - startIndex;
-		if (capacity < slice.length + length) {
+		if (pd.extent.size - stopIndex < length) {
 			return false;
 		}
 

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -472,7 +472,7 @@ unittest extend {
 	assert(!threadCache.extend(p0[0 .. 100], 16285));
 	assert(!threadCache.extend(p0[50 .. 100], 16285));
 
-	// Extend by size zero is permitted if capacity>0, but has no effect:
+	// Extend by size zero is permitted but has no effect:
 	assert(threadCache.extend(p0[100 .. 100], 0));
 	assert(threadCache.extend(p0[0 .. 100], 0));
 	assert(threadCache.getCapacity(p0[0 .. 100]) == 16384);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -494,7 +494,6 @@ unittest extend {
 
 	// Extend the upper half:
 	assert(threadCache.extend(p0[125 .. 150], 100));
-
 	assert(threadCache.getCapacity(p0[150 .. 250]) == 16234);
 
 	// Original's capacity becomes 0:

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -151,13 +151,8 @@ public:
 	 * See also: https://dlang.org/spec/arrays.html#capacity-reserve
 	 */
 	size_t getCapacity(const void[] slice) {
-		auto pd = maybeGetPageDescriptor(slice.ptr);
-		if (pd.extent is null) {
-			return 0;
-		}
-
-		// Appendable slabs are not supported.
-		if (pd.isSlab()) {
+		PageDescriptor pd;
+		if (!getAppendablePageDescriptor(slice, pd)) {
 			return 0;
 		}
 
@@ -178,13 +173,8 @@ public:
 			return false;
 		}
 
-		auto pd = maybeGetPageDescriptor(slice.ptr);
-		if (pd.extent is null) {
-			return false;
-		}
-
-		// Appendable slabs are not supported.
-		if (pd.isSlab()) {
+		PageDescriptor pd;
+		if (!getAppendablePageDescriptor(slice, pd)) {
 			return false;
 		}
 
@@ -280,6 +270,22 @@ public:
 	}
 
 private:
+	bool getAppendablePageDescriptor(const void[] slice,
+	                                 ref PageDescriptor pd) {
+		pd = maybeGetPageDescriptor(slice.ptr);
+
+		if (pd.extent is null) {
+			return false;
+		}
+
+		// Appendable slabs are not supported.
+		if (pd.isSlab()) {
+			return false;
+		}
+
+		return true;
+	}
+
 	auto getPageDescriptor(void* ptr) {
 		auto pd = maybeGetPageDescriptor(ptr);
 		assert(pd.extent !is null);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -479,6 +479,18 @@ unittest extend {
 	assert(threadCache.extend(p0[50 .. 100], 0));
 	assert(threadCache.getCapacity(p0[50 .. 100]) == 16334);
 
+	// Extend by zero is permitted even when no capacity:
+	assert(threadCache.extend(nonAppendable[0 .. 100], 0));
+
+	void* nullPtr = null;
+	assert(threadCache.extend(nullPtr[0 .. 100], 0));
+
+	void* stackPtr = &nullPtr;
+	assert(threadCache.extend(stackPtr[0 .. 100], 0));
+
+	void* tlPtr = &threadCache;
+	assert(threadCache.extend(tlPtr[0 .. 100], 0));
+
 	// Valid extend :
 	assert(threadCache.extend(p0[0 .. 100], 50));
 	assert(threadCache.getCapacity(p0[100 .. 150]) == 16284);

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -436,71 +436,74 @@ unittest getCapacity {
 	auto p5 = threadCache.realloc(p4, 20000, false);
 	assert(p5 !is p4);
 	assert(threadCache.getCapacity(p5[0 .. 16000]) == 20480);
+}
 
+unittest Append {
 	// Append.
+	auto nonAppendable = threadCache.alloc(100, false);
 
 	// Attempt to append a non-appendable:
 	assert(threadCache.append(nonAppendable[0 .. 100], 1) is null);
 
 	// Make an appendable alloc:
-	auto p6 = threadCache.allocAppendable(100, false);
-	assert(threadCache.getCapacity(p6[0 .. 100]) == 16384);
+	auto p0 = threadCache.allocAppendable(100, false);
+	assert(threadCache.getCapacity(p0[0 .. 100]) == 16384);
 
 	// Attempt append to slices with capacity 0:
-	assert(threadCache.append(p6[0 .. 0], 50) is null);
-	assert(threadCache.append(p6[0 .. 99], 50) is null);
-	assert(threadCache.append(p6[1 .. 99], 50) is null);
-	assert(threadCache.append(p6[0 .. 50], 50) is null);
+	assert(threadCache.append(p0[0 .. 0], 50) is null);
+	assert(threadCache.append(p0[0 .. 99], 50) is null);
+	assert(threadCache.append(p0[1 .. 99], 50) is null);
+	assert(threadCache.append(p0[0 .. 50], 50) is null);
 
 	// Attempt append with non-allocatable length:
-	assert(threadCache.append(p6[0 .. 100], 0) is null);
+	assert(threadCache.append(p0[0 .. 100], 0) is null);
 
 	// Attempt append with insufficient space:
-	assert(threadCache.append(p6[0 .. 100], 16285) is null);
-	assert(threadCache.append(p6[50 .. 100], 16285) is null);
+	assert(threadCache.append(p0[0 .. 100], 16285) is null);
+	assert(threadCache.append(p0[50 .. 100], 16285) is null);
 
 	// Valid append :
-	auto p7 = threadCache.append(p6[0 .. 100], 50);
-	assert(p7 == p6 + 100);
-	assert(threadCache.getCapacity(p7[0 .. 50]) == 16284);
+	auto p3 = threadCache.append(p0[0 .. 100], 50);
+	assert(p3 == p0 + 100);
+	assert(threadCache.getCapacity(p3[0 .. 50]) == 16284);
 
 	// Capacity of old slice becomes 0, as there is now data in front of it:
-	assert(threadCache.getCapacity(p6[0 .. 100]) == 0);
+	assert(threadCache.getCapacity(p0[0 .. 100]) == 0);
 
 	// Capacity of a slice including the original and the append:
-	assert(threadCache.getCapacity(p6[0 .. 150]) == 16384);
+	assert(threadCache.getCapacity(p0[0 .. 150]) == 16384);
 
-	// Append the upper half of p7:
-	auto p8 = threadCache.append(p7[25 .. 50], 100);
-	assert(threadCache.getCapacity(p8[0 .. 100]) == 16234);
+	// Append the upper half of p3:
+	auto p4 = threadCache.append(p3[25 .. 50], 100);
+	assert(threadCache.getCapacity(p4[0 .. 100]) == 16234);
 
 	// Original's capacity becomes 0:
-	assert(threadCache.getCapacity(p7[25 .. 50]) == 0);
+	assert(threadCache.getCapacity(p3[25 .. 50]) == 0);
 
 	// Capacity of a slice including original and appended:
-	assert(threadCache.getCapacity(p7[25 .. 150]) == 16259);
+	assert(threadCache.getCapacity(p3[25 .. 150]) == 16259);
 
 	// Capacity of earlier slice elongated to cover the appends :
-	assert(threadCache.getCapacity(p6[0 .. 250]) == 16384);
+	assert(threadCache.getCapacity(p0[0 .. 250]) == 16384);
 
 	// Append a zero-length slice existing at the start of the free space:
-	auto p9 = threadCache.append(p6[250 .. 250], 200);
-	assert(threadCache.getCapacity(p9[0 .. 200]) == 16134);
+	auto p5 = threadCache.append(p0[250 .. 250], 200);
+	assert(threadCache.getCapacity(p5[0 .. 200]) == 16134);
 
 	// Capacity of the old slice is now 0:
-	assert(threadCache.getCapacity(p6[0 .. 250]) == 0);
+	assert(threadCache.getCapacity(p0[0 .. 250]) == 0);
 
 	// Capacity of a slice which includes the original and the append:
-	assert(threadCache.getCapacity(p6[0 .. 450]) == 16384);
+	assert(threadCache.getCapacity(p0[0 .. 450]) == 16384);
 
 	// Append so as to fill up all but one byte of free space:
-	auto p10 = threadCache.append(p6[0 .. 450], 15933);
-	assert(threadCache.getCapacity(p6[16383 .. 16383]) == 1);
+	auto p6 = threadCache.append(p0[0 .. 450], 15933);
+	assert(threadCache.getCapacity(p0[16383 .. 16383]) == 1);
 
 	// Append, filling up last byte of free space:
-	auto p11 = threadCache.append(p6[16383 .. 16383], 1);
-	assert(threadCache.getCapacity(p6[0 .. 16384]) == 16384);
+	auto p7 = threadCache.append(p0[16383 .. 16383], 1);
+	assert(threadCache.getCapacity(p0[0 .. 16384]) == 16384);
 
 	// Attempt to append, but we're full:
-	assert(threadCache.append(p6[0 .. 16384], 1) == null);
+	assert(threadCache.append(p0[0 .. 16384], 1) == null);
 }


### PR DESCRIPTION
`extend()` attempts to extend an alloc by a given length.
If the alloc is not appendable, or there is insufficient capacity, null is returned.
If succeeds, returns a pointer to the newly-available memory.