### PR TITLE
clear() for hpd and emap

### DIFF
--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -39,7 +39,11 @@ public:
 	}
 
 	void clear(Extent* extent) shared {
-		tree.clearRange(extent.address, extent.size);
+		clear(extent.address, extent.size);
+	}
+
+	void clear(void* address, size_t size) shared {
+		tree.clearRange(address, size);
 	}
 }
 
@@ -186,5 +190,25 @@ unittest ExtentMap {
 	for (auto p = ptr; p < end; p += PageSize) {
 		assert(emap.lookup(p).data == pd.data);
 		pd = pd.next();
+	}
+
+	emap.clear(e);
+
+	// Shrink a range.
+	e.at(ptr, 5 * PageSize, null, ec);
+	emap.remap(e, ec);
+	pd = PageDescriptor(e, ec);
+
+	emap.clear(e.address + 3 * PageSize, 2 * PageSize);
+	e.at(ptr, 3 * PageSize, null, ec);
+
+	for (auto p = ptr; p < e.address + 3 * PageSize; p += PageSize) {
+		assert(emap.lookup(p).data == pd.data);
+		pd = pd.next();
+	}
+
+	for (auto p = e.address + 3 * PageSize; p < e.address + 5 * PageSize;
+	     p += PageSize) {
+		assert(emap.lookup(p).data == 0);
 	}
 }

--- a/sdlib/d/gc/hpd.d
+++ b/sdlib/d/gc/hpd.d
@@ -111,7 +111,7 @@ public:
 		return bestIndex;
 	}
 
-	void release(uint index, uint pages) {
+	void clear(uint index, uint pages) {
 		// FIXME: in contract.
 		assert(pages > 0 && pages <= PageCount, "Invalid number of pages!");
 		assert(index <= PageCount - pages, "Invalid index!");
@@ -121,9 +121,13 @@ public:
 		auto start = allocatedPages.findSetBackward(index) + 1;
 		auto stop = allocatedPages.findSet(index + pages - 1);
 
-		allocCount--;
 		usedCount -= pages;
 		longestFreeRange = max(longestFreeRange, stop - start);
+	}
+
+	void release(uint index, uint pages) {
+		clear(index, pages);
+		allocCount--;
 	}
 }
 
@@ -222,4 +226,52 @@ unittest hugePageDescriptor {
 
 	hpd.release(PageCount - 4, 4);
 	checkRangeState(PageCount / 4 - 7, PageCount - 28, 20);
+}
+
+unittest hugePageDescriptorClear {
+	enum PageCount = HugePageDescriptor.PageCount;
+	HugePageDescriptor hpd;
+
+	void checkRangeState(uint nalloc, uint nused, uint lfr) {
+		assert(hpd.allocCount == nalloc);
+		assert(hpd.usedCount == nused);
+		assert(hpd.longestFreeRange == lfr);
+		assert(hpd.allocatedPages.countBits(0, PageCount) == nused);
+	}
+
+	// First allocation.
+	assert(hpd.reserve(200) == 0);
+	checkRangeState(1, 200, PageCount - 200);
+
+	// Second allocation:
+	assert(hpd.reserve(100) == 200);
+	checkRangeState(2, 300, PageCount - 300);
+
+	// Third allocation, and we're full:
+	assert(hpd.reserve(212) == 300);
+	checkRangeState(3, 512, 0);
+
+	// Shrink the first allocation, make lfr of 100:
+	hpd.clear(100, 100);
+	checkRangeState(3, 412, PageCount - 412);
+
+	// Shrink the second allocation, lfr is still 100:
+	hpd.clear(299, 1);
+	checkRangeState(3, 411, PageCount - 412);
+
+	// Shrink the third allocation, lfr is still 100:
+	hpd.clear(500, 12);
+	checkRangeState(3, 399, PageCount - 412);
+
+	// Release the third allocation:
+	hpd.release(300, 200);
+	checkRangeState(2, 199, 213);
+
+	// Release the second allocation:
+	hpd.release(200, 99);
+	checkRangeState(1, 100, PageCount - 100);
+
+	// Release the first allocation:
+	hpd.release(0, 100);
+	checkRangeState(0, 0, PageCount);
 }


### PR DESCRIPTION
Split from https://github.com/snazzy-d/sdc/pull/289 .

`clear()` in emap allows removal of a portion of a mapping.
`clear()` in hpd similarly.
