### PR TITLE
Split binInfos from bin into new module 'slab'.

### DIFF
--- a/sdlib/d/gc/allocclass.d
+++ b/sdlib/d/gc/allocclass.d
@@ -18,7 +18,6 @@ ubyte getAllocClass(size_t pages) {
 }
 
 unittest getAllocClass {
-	import d.gc.slab;
 	assert(getAllocClass(0) == 0xff);
 
 	uint[] boundaries =
@@ -42,7 +41,6 @@ ubyte getFreeSpaceClass(size_t pages) {
 }
 
 unittest getFreeSpaceClass {
-	import d.gc.slab;
 	assert(getFreeSpaceClass(0) == 0xff);
 
 	uint[] boundaries =

--- a/sdlib/d/gc/allocclass.d
+++ b/sdlib/d/gc/allocclass.d
@@ -18,7 +18,7 @@ ubyte getAllocClass(size_t pages) {
 }
 
 unittest getAllocClass {
-	import d.gc.bin;
+	import d.gc.slab;
 	assert(getAllocClass(0) == 0xff);
 
 	uint[] boundaries =
@@ -42,7 +42,7 @@ ubyte getFreeSpaceClass(size_t pages) {
 }
 
 unittest getFreeSpaceClass {
-	import d.gc.bin;
+	import d.gc.slab;
 	assert(getFreeSpaceClass(0) == 0xff);
 
 	uint[] boundaries =

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -165,8 +165,11 @@ public:
 package:
 	Extent* allocSlab(shared(ExtentMap)* emap, ubyte sizeClass) shared {
 		auto ec = ExtentClass.slab(sizeClass);
+
 		import d.gc.slab;
-		auto e = allocPages(binInfos[sizeClass].needPages, ec);
+		auto neededPages = binInfos[sizeClass].needPages;
+
+		auto e = allocPages(neededPages, ec);
 		if (unlikely(e is null)) {
 			return null;
 		}

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -165,6 +165,7 @@ public:
 package:
 	Extent* allocSlab(shared(ExtentMap)* emap, ubyte sizeClass) shared {
 		auto ec = ExtentClass.slab(sizeClass);
+		import d.gc.slab;
 		auto e = allocPages(binInfos[sizeClass].needPages, ec);
 		if (unlikely(e is null)) {
 			return null;

--- a/sdlib/d/gc/bin.d
+++ b/sdlib/d/gc/bin.d
@@ -59,7 +59,7 @@ struct Bin {
 		auto sg = SlabAllocGeometry(ptr, pd);
 		assert(ptr is sg.address);
 
-		auto slots = binInfos[sg.sizeClass].slots;
+		auto slots = binInfos[pd.sizeClass].slots;
 
 		mutex.lock();
 		scope(exit) mutex.unlock();

--- a/sdlib/d/gc/bin.d
+++ b/sdlib/d/gc/bin.d
@@ -55,8 +55,8 @@ struct Bin {
 		assert(&arena.bins[pd.sizeClass] == &this,
 		       "Invalid arena or sizeClass!");
 
-		auto sg = SlabAllocGeometry(ptr, pd, true);
-		auto slots = binInfos[sg.sc].slots;
+		auto sg = SlabAllocGeometry(ptr, pd);
+		auto slots = binInfos[sg.sizeClass].slots;
 
 		mutex.lock();
 		scope(exit) mutex.unlock();

--- a/sdlib/d/gc/bin.d
+++ b/sdlib/d/gc/bin.d
@@ -55,7 +55,7 @@ struct Bin {
 		assert(&arena.bins[pd.sizeClass] == &this,
 		       "Invalid arena or sizeClass!");
 
-		auto sg = slabAllocGeometry(ptr, pd, true);
+		auto sg = SlabAllocGeometry(ptr, pd, true);
 		auto slots = binInfos[sg.sc].slots;
 
 		mutex.lock();

--- a/sdlib/d/gc/extent.d
+++ b/sdlib/d/gc/extent.d
@@ -124,7 +124,7 @@ private:
 		bits |= ulong(arenaIndex) << 32;
 
 		if (ec.isSlab()) {
-			import d.gc.bin;
+			import d.gc.slab;
 			bits |= ulong(binInfos[ec.sizeClass].slots) << 48;
 
 			slabData.clear();

--- a/sdlib/d/gc/sizeclass.d
+++ b/sdlib/d/gc/sizeclass.d
@@ -145,7 +145,7 @@ ubyte getSizeClass(size_t size) {
 }
 
 unittest getSizeClass {
-	import d.gc.bin;
+	import d.gc.slab;
 	assert(getSizeClass(0) == InvalidBinID);
 
 	size_t[] boundaries =
@@ -167,7 +167,7 @@ unittest getSizeClass {
 
 size_t getSizeFromClass(uint sizeClass) {
 	if (isSmallSizeClass(sizeClass)) {
-		import d.gc.bin;
+		import d.gc.slab;
 		return binInfos[sizeClass].itemSize;
 	}
 
@@ -195,7 +195,7 @@ unittest getSizeFromClass {
 }
 
 auto getBinInfos() {
-	import d.gc.bin;
+	import d.gc.slab;
 	BinInfo[ClassCount.Small] bins;
 
 	computeSizeClass((uint id, uint grp, uint delta, uint ndelta) {

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -7,7 +7,7 @@ enum InvalidBinID = 0xff;
 
 struct SlabAllocGeometry {
 	void* address;
-	size_t size;
+	uint size;
 	uint index;
 
 	this(void* ptr, PageDescriptor pd) {

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -1,22 +1,18 @@
 module d.gc.slab;
 
 import d.gc.emap;
-import d.gc.extent;
 import d.gc.spec;
 
 enum InvalidBinID = 0xff;
 
 struct SlabAllocGeometry {
-	Extent* e;
 	void* address;
 	size_t size;
 	uint index;
 	uint sizeClass;
 
 	this(void* ptr, PageDescriptor pd) {
-		assert(pd.extent !is null, "Extent is null!");
 		assert(pd.isSlab(), "Expected a slab!");
-		assert(pd.extent.contains(ptr), "ptr not in slab!");
 
 		sizeClass = pd.sizeClass;
 
@@ -25,7 +21,6 @@ struct SlabAllocGeometry {
 		index = binInfos[sizeClass].computeIndex(offset);
 
 		auto base = ptr - offset;
-		assert(ptr is base + index * binInfos[sizeClass].itemSize);
 		size = binInfos[sizeClass].itemSize;
 		address = base + index * size;
 	}

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -9,19 +9,16 @@ struct SlabAllocGeometry {
 	void* address;
 	size_t size;
 	uint index;
-	uint sizeClass;
 
 	this(void* ptr, PageDescriptor pd) {
 		assert(pd.isSlab(), "Expected a slab!");
 
-		sizeClass = pd.sizeClass;
-
 		import d.gc.util;
 		auto offset = alignDownOffset(ptr, PageSize) + pd.index * PageSize;
-		index = binInfos[sizeClass].computeIndex(offset);
+		index = binInfos[pd.sizeClass].computeIndex(offset);
 
 		auto base = ptr - offset;
-		size = binInfos[sizeClass].itemSize;
+		size = binInfos[pd.sizeClass].itemSize;
 		address = base + index * size;
 	}
 }

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -18,7 +18,6 @@ struct SlabAllocGeometry {
 		assert(pd.isSlab(), "Expected a slab!");
 		assert(pd.extent.contains(ptr), "ptr not in slab!");
 
-		e = pd.extent;
 		sizeClass = pd.sizeClass;
 
 		import d.gc.util;

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -26,6 +26,7 @@ struct SlabAllocGeometry {
 		index = binInfos[sizeClass].computeIndex(offset);
 
 		auto base = ptr - offset;
+		assert(ptr is base + index * binInfos[sizeClass].itemSize);
 		size = binInfos[sizeClass].itemSize;
 		address = base + index * size;
 	}

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -1,0 +1,74 @@
+module d.gc.slab;
+
+import d.gc.emap;
+import d.gc.extent;
+import d.gc.spec;
+
+enum InvalidBinID = 0xff;
+
+struct slabAllocGeometry {
+	Extent* e;
+	uint sc;
+	size_t size;
+	uint index;
+	void* address;
+
+	this(void* ptr, PageDescriptor pd, bool ptrIsStart) {
+		assert(pd.extent !is null, "Extent is null!");
+		assert(pd.isSlab(), "Expected a slab!");
+		assert(pd.extent.contains(ptr), "ptr not in slab!");
+
+		e = pd.extent;
+		sc = pd.sizeClass;
+
+		import d.gc.util;
+		auto offset = alignDownOffset(ptr, PageSize) + pd.index * PageSize;
+		index = binInfos[sc].computeIndex(offset);
+
+		auto base = ptr - offset;
+		size = binInfos[sc].itemSize;
+		address = base + index * size;
+
+		assert(!ptrIsStart || (ptr is address),
+		       "ptr does not point to start of slab alloc!");
+	}
+}
+
+struct BinInfo {
+	ushort itemSize;
+	ushort slots;
+	ubyte needPages;
+	ubyte shift;
+	ushort mul;
+
+	this(ushort itemSize, ubyte shift, ubyte needPages, ushort slots) {
+		this.itemSize = itemSize;
+		this.slots = slots;
+		this.needPages = needPages;
+		this.shift = (shift + 17) & 0xff;
+
+		// XXX: out contract
+		enum MaxShiftMask = (8 * size_t.sizeof) - 1;
+		assert(this.shift == (this.shift & MaxShiftMask));
+
+		/**
+		 * This is a bunch of magic values used to avoid requiring
+		 * division to find the index of an item within a run.
+		 *
+		 * Computed using finddivisor.d
+		 */
+		ushort[4] mulIndices = [32768, 26215, 21846, 18725];
+		auto tag = (itemSize >> shift) & 0x03;
+		this.mul = mulIndices[tag];
+	}
+
+	uint computeIndex(size_t offset) const {
+		// FIXME: in contract.
+		assert(offset < needPages * PageSize, "Offset out of bounds!");
+
+		return cast(uint) ((offset * mul) >> shift);
+	}
+}
+
+import d.gc.sizeclass;
+immutable BinInfo[ClassCount.Small] binInfos = getBinInfos();

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -8,29 +8,26 @@ enum InvalidBinID = 0xff;
 
 struct SlabAllocGeometry {
 	Extent* e;
-	uint sc;
+	void* address;
 	size_t size;
 	uint index;
-	void* address;
+	uint sizeClass;
 
-	this(void* ptr, PageDescriptor pd, bool ptrIsStart) {
+	this(void* ptr, PageDescriptor pd) {
 		assert(pd.extent !is null, "Extent is null!");
 		assert(pd.isSlab(), "Expected a slab!");
 		assert(pd.extent.contains(ptr), "ptr not in slab!");
 
 		e = pd.extent;
-		sc = pd.sizeClass;
+		sizeClass = pd.sizeClass;
 
 		import d.gc.util;
 		auto offset = alignDownOffset(ptr, PageSize) + pd.index * PageSize;
-		index = binInfos[sc].computeIndex(offset);
+		index = binInfos[sizeClass].computeIndex(offset);
 
 		auto base = ptr - offset;
-		size = binInfos[sc].itemSize;
+		size = binInfos[sizeClass].itemSize;
 		address = base + index * size;
-
-		assert(!ptrIsStart || (ptr is address),
-		       "ptr does not point to start of slab alloc!");
 	}
 }
 

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -6,7 +6,7 @@ import d.gc.spec;
 
 enum InvalidBinID = 0xff;
 
-struct slabAllocGeometry {
+struct SlabAllocGeometry {
 	Extent* e;
 	uint sc;
 	size_t size;


### PR DESCRIPTION
Split from https://github.com/snazzy-d/sdc/pull/287 .

Create new module `slab`, to remove spurious dependency on `bin` where only `binInfos` is required.
Factor out slab index-finder logic into struct `slabAllocGeometry` in `slab`.
