### PR TITLE
Support for growing allocations in resizeLarge; tests for same.

### DIFF
--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -276,12 +276,14 @@ private:
 		assert(!e.isHuge(), "Does not support huge!");
 		assert(pages > 0 && pages > e.pageCount, "Invalid page count!");
 
-		uint delta = pages - e.pageCount;
-		uint index = e.hpdIndex + e.pageCount;
+		auto n = e.hpdIndex;
 
-		if (index + delta > PagesInHugePage) {
+		if (n + pages > PagesInHugePage) {
 			return false;
 		}
+
+		uint delta = pages - e.pageCount;
+		uint index = n + e.pageCount;
 
 		auto prevEnd = e.address + e.size;
 
@@ -295,9 +297,8 @@ private:
 			return false;
 		}
 
-		auto addedSize = delta * PageSize;
-
-		if (emap.map(prevEnd, addedSize, PageDescriptor(e, e.extentClass))) {
+		if (emap.map(prevEnd, delta * PageSize,
+		             PageDescriptor(e, e.extentClass))) {
 			return true;
 		}
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -298,7 +298,7 @@ private:
 			}
 		}
 
-		if (emap.enlarge(prevEnd, delta * PageSize)) {
+		if (emap.extend(prevEnd, delta * PageSize)) {
 			return true;
 		}
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -850,10 +850,11 @@ unittest resizeLargeGrow {
 		assert(pdAfter.extent !is pd.extent);
 
 		// Confirm that the extent correctly grew and remapped:
+		auto pdBase = pd;
 		for (auto p = pd.extent.address; p < pd.extent.address + pd.extent.size;
 		     p += PageSize) {
 			auto probe = emap.lookup(p);
-			assert(probe.extent == pd.extent);
+			assert(probe.extent == pdBase.extent);
 			assert(probe.data == pd.data);
 			pd = pd.next();
 		}

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -842,17 +842,17 @@ unittest resizeLargeGrow {
 	}
 
 	void checkGrowLarge(PageDescriptor pd, uint pages) {
-		assert(arena.resizeLarge(&emap, pd.extent, pages * PageSize));
-		assert(pd.extent.size == pages * PageSize);
+		auto e = pd.extent;
+
+		assert(arena.resizeLarge(&emap, e, pages * PageSize));
+		assert(e.size == pages * PageSize);
 
 		// Confirm that the page after the end of the extent is not included in the map:
-		auto pdAfter = emap.lookup(pd.extent.address + pd.extent.size);
-		assert(pdAfter.extent !is pd.extent);
+		auto pdAfter = emap.lookup(e.address + e.size);
+		assert(pdAfter.extent !is e);
 
 		// Confirm that the extent correctly grew and remapped:
-		auto e = pd.extent;
-		for (auto p = pd.extent.address; p < pd.extent.address + pd.extent.size;
-		     p += PageSize) {
+		for (auto p = e.address; p < e.address + e.size; p += PageSize) {
 			auto probe = emap.lookup(p);
 			assert(probe.extent == e);
 			assert(probe.data == pd.data);

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -274,7 +274,7 @@ private:
 
 	bool growAlloc(shared(ExtentMap)* emap, Extent* e, uint pages) shared {
 		assert(!e.isHuge(), "Does not support huge!");
-		assert(pages > 0 && pages > e.pageCount, "Invalid page count!");
+		assert(pages > e.pageCount, "Invalid page count!");
 
 		auto n = e.hpdIndex;
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -284,7 +284,6 @@ private:
 
 		uint delta = pages - e.pageCount;
 		uint index = n + e.pageCount;
-
 		auto prevEnd = e.address + e.size;
 
 		mutex.lock();

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -850,11 +850,11 @@ unittest resizeLargeGrow {
 		assert(pdAfter.extent !is pd.extent);
 
 		// Confirm that the extent correctly grew and remapped:
-		auto pdBase = pd;
+		auto e = pd.extent;
 		for (auto p = pd.extent.address; p < pd.extent.address + pd.extent.size;
 		     p += PageSize) {
 			auto probe = emap.lookup(p);
-			assert(probe.extent == pdBase.extent);
+			assert(probe.extent == e);
 			assert(probe.data == pd.data);
 			pd = pd.next();
 		}

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -286,14 +286,14 @@ private:
 		uint index = n + e.pageCount;
 		auto prevEnd = e.address + e.size;
 
-		mutex.lock();
-		// Try to grow:
-		auto didGrow =
-			(cast(Arena*) &this).growAllocImpl(e, index, pages, delta);
-		mutex.unlock();
+		{
+			mutex.lock();
+			scope(exit) mutex.unlock();
 
-		if (!didGrow) {
-			return false;
+			// Try to grow:
+			if (!(cast(Arena*) &this).growAllocImpl(e, index, pages, delta)) {
+				return false;
+			}
 		}
 
 		if (emap.map(prevEnd, delta * PageSize,

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -275,8 +275,8 @@ private:
 	bool growAlloc(shared(ExtentMap)* emap, Extent* e, uint pages) shared {
 		assert(!e.isHuge(), "Does not support huge!");
 
-		auto currPages = e.pageCount;
-		assert(pages > currPages, "Invalid page count!");
+		auto origPages = e.pageCount;
+		assert(pages > origPages, "Invalid page count!");
 
 		auto n = e.hpdIndex;
 
@@ -284,8 +284,8 @@ private:
 			return false;
 		}
 
-		uint delta = pages - currPages;
-		uint index = n + currPages;
+		uint delta = pages - origPages;
+		uint index = n + origPages;
 
 		{
 			mutex.lock();
@@ -298,8 +298,8 @@ private:
 		}
 
 		// Map the new pages:
-		auto lastIndex = currPages & 0xF;
-		auto mapAddr = e.address + (currPages - lastIndex) * PageSize;
+		auto lastIndex = origPages & 0xF;
+		auto mapAddr = e.address + (origPages - lastIndex) * PageSize;
 		auto mapSize = (delta + lastIndex) * PageSize;
 
 		if (emap.map(mapAddr, mapSize, PageDescriptor(e, e.extentClass))) {

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -422,7 +422,7 @@ private:
 	bool growAllocImpl(Extent* e, uint index, uint pages, uint delta) {
 		assert(mutex.isHeld(), "Mutex not held!");
 		assert(index > 0 && index <= PagesInHugePage - delta, "Invalid index!");
-		assert(pages > 0 && pages <= PagesInHugePage - 1,
+		assert(pages > 0 && pages <= PagesInHugePage,
 		       "Invalid number of pages!");
 		assert(delta > 0, "Invalid delta!");
 
@@ -885,6 +885,20 @@ unittest resizeLargeGrow {
 	assert(arena.resizeLarge(&emap, pd0.extent, 99 * PageSize));
 	assert(pd0.extent.address is ptr0);
 	assert(pd0.extent.size == 99 * PageSize);
+
+	// Confirm that hpd is full:
+	assert(pd0.extent.hpd.full);
+
+	// Free allocation 2:
+	arena.free(&emap, pd2, ptr2);
+
+	// Confirm that hpd is not full:
+	assert(!pd0.extent.hpd.full);
+
+	// Grow allocation 0 to fill hpd :
+	assert(arena.resizeLarge(&emap, pd0.extent, 512 * PageSize));
+	assert(pd0.extent.address is ptr0);
+	assert(pd0.extent.size == 512 * PageSize);
 
 	// Confirm that hpd is full:
 	assert(pd0.extent.hpd.full);

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -299,10 +299,10 @@ private:
 
 		// Map the new pages:
 		auto lastPdIndex = origPages & 0xF;
-		auto mapAddr = e.address + (origPages - lastPdIndex) * PageSize;
-		auto mapSize = (delta + lastPdIndex) * PageSize;
+		auto mapAddr = e.address + origPages * PageSize;
+		auto pd = PageDescriptor(e, e.extentClass);
 
-		if (emap.map(mapAddr, mapSize, PageDescriptor(e, e.extentClass))) {
+		if (emap.map(mapAddr, delta * PageSize, pd.addIndex(lastPdIndex))) {
 			return true;
 		}
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -298,9 +298,9 @@ private:
 		}
 
 		// Map the new pages:
-		auto lastIndex = origPages & 0xF;
-		auto mapAddr = e.address + (origPages - lastIndex) * PageSize;
-		auto mapSize = (delta + lastIndex) * PageSize;
+		auto lastPdIndex = origPages & 0xF;
+		auto mapAddr = e.address + (origPages - lastPdIndex) * PageSize;
+		auto mapSize = (delta + lastPdIndex) * PageSize;
 
 		if (emap.map(mapAddr, mapSize, PageDescriptor(e, e.extentClass))) {
 			return true;

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -298,7 +298,12 @@ private:
 			}
 		}
 
-		if (emap.extend(prevEnd, delta * PageSize)) {
+		// Map the new pages:
+		auto lastIndex = currPages & 0xF;
+		auto mapAddr = e.address + (currPages - lastIndex) * PageSize;
+		auto mapSize = (delta + lastIndex) * PageSize;
+
+		if (emap.map(mapAddr, mapSize, PageDescriptor(e, e.extentClass))) {
 			return true;
 		}
 
@@ -437,7 +442,6 @@ private:
 		}
 
 		if (!hpd.full) {
-			assert(!hpd.empty);
 			registerHPD(hpd);
 		}
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -842,13 +842,13 @@ unittest resizeLargeGrow {
 		auto e = pd.extent;
 		assert(e !is null);
 		assert(e.address is ptr);
-		assert(e.size == pages * PageSize);
+		assert(e.pageCount == pages);
 		return e;
 	}
 
 	void checkGrowLarge(Extent* e, uint pages) {
 		assert(arena.resizeLarge(&emap, e, pages * PageSize));
-		assert(e.size == pages * PageSize);
+		assert(e.pageCount == pages);
 
 		// Confirm that the page after the end of the extent is not included in the map:
 		auto pdAfter = emap.lookup(e.address + e.size);

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -902,4 +902,7 @@ unittest resizeLargeGrow {
 
 	// Confirm that hpd is full:
 	assert(pd0.extent.hpd.full);
+
+	// Free allocation 0:
+	arena.free(&emap, pd0, ptr0);
 }

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -876,6 +876,17 @@ unittest resizeLargeGrow {
 	assert(pd0.extent.address is ptr0);
 	assert(pd0.extent.size == 44 * PageSize);
 
+	// Confirm that the extent correctly grew and remapped:
+	for (auto p = pd0.extent.address; p < pd0.extent.address + pd0.extent.size;
+	     p += PageSize) {
+		auto pd0probe = emap.lookup(p);
+		assert(pd0probe.extent == pd0.extent);
+	}
+
+	// Confirm that the page after the end of the extent is not included in the map:
+	auto pd0after = emap.lookup(pd0.extent.address + pd0.extent.size);
+	assert(pd0after.extent is null);
+
 	// Try to grow allocation 0 but fail:
 	assert(!arena.resizeLarge(&emap, pd0.extent, uint.max * PageSize));
 	assert(!arena.resizeLarge(&emap, pd0.extent, 9999 * PageSize));

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -302,7 +302,7 @@ private:
 		auto mapAddr = e.address + origPages * PageSize;
 		auto pd = PageDescriptor(e, e.extentClass);
 
-		if (emap.map(mapAddr, delta * PageSize, pd.addIndex(pdIndex))) {
+		if (emap.map(mapAddr, delta * PageSize, pd.next(pdIndex))) {
 			return true;
 		}
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -298,11 +298,11 @@ private:
 		}
 
 		// Map the new pages:
-		auto lastPdIndex = origPages & 0xF;
+		auto pdIndex = origPages & 0xF;
 		auto mapAddr = e.address + origPages * PageSize;
 		auto pd = PageDescriptor(e, e.extentClass);
 
-		if (emap.map(mapAddr, delta * PageSize, pd.addIndex(lastPdIndex))) {
+		if (emap.map(mapAddr, delta * PageSize, pd.addIndex(pdIndex))) {
 			return true;
 		}
 

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -286,7 +286,6 @@ private:
 
 		uint delta = pages - currPages;
 		uint index = n + currPages;
-		auto prevEnd = e.address + e.size;
 
 		{
 			mutex.lock();

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -274,7 +274,9 @@ private:
 
 	bool growAlloc(shared(ExtentMap)* emap, Extent* e, uint pages) shared {
 		assert(!e.isHuge(), "Does not support huge!");
-		assert(pages > e.pageCount, "Invalid page count!");
+
+		auto currPages = e.pageCount;
+		assert(pages > currPages, "Invalid page count!");
 
 		auto n = e.hpdIndex;
 
@@ -282,8 +284,8 @@ private:
 			return false;
 		}
 
-		uint delta = pages - e.pageCount;
-		uint index = n + e.pageCount;
+		uint delta = pages - currPages;
+		uint index = n + currPages;
 		auto prevEnd = e.address + e.size;
 
 		{

--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -851,11 +851,11 @@ unittest resizeLargeGrow {
 
 	// Allocation 1: 64 pages:
 	auto pd1 = makeAllocLarge(64);
-	assert(pd1.extent.hpd == pd0.extent.hpd);
+	assert(pd1.extent.address == pd0.extent.address + pd0.extent.size);
 
 	// Allocation 2: 128 pages:
 	auto pd2 = makeAllocLarge(128);
-	assert(pd2.extent.hpd == pd1.extent.hpd);
+	assert(pd2.extent.address == pd1.extent.address + pd1.extent.size);
 
 	// Try to grow allocation 0, but cannot, there is no space to grow:
 	assert(!arena.resizeLarge(&emap, pd0.extent, 36 * PageSize));
@@ -875,7 +875,6 @@ unittest resizeLargeGrow {
 	// Grow allocation 0:
 	checkGrowLarge(pd0, 44);
 
-	// Confirm that the extent correctly grew and remapped:
 	// Confirm that the extent correctly grew and remapped:
 	auto pd0x = pd0;
 	for (auto p = pd0.extent.address; p < pd0.extent.address + pd0.extent.size;

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -27,7 +27,7 @@ public:
 		return leaf is null ? PageDescriptor(0) : leaf.load();
 	}
 
-	bool enlarge(void* address, size_t size) shared {
+	bool extend(void* address, size_t size) shared {
 		auto lastPd = lookup(address - PageSize);
 		assert(lastPd.extent !is null, "Nothing mapped before address!");
 
@@ -223,13 +223,13 @@ unittest ExtentMap {
 		assert(emap.lookup(p).data == 0);
 	}
 
-	// Enlarge a range.
+	// Extend a range.
 	e.at(ptr, 5 * PageSize, null, ec);
 	emap.remap(e, ec);
 	pd = PageDescriptor(e, ec);
 
 	e.at(ptr, 40 * PageSize, null, ec);
-	assert(emap.enlarge(ptr + 5 * PageSize, 35 * PageSize));
+	assert(emap.extend(ptr + 5 * PageSize, 35 * PageSize));
 
 	for (auto p = ptr; p < e.address + e.size; p += PageSize) {
 		auto getpd = emap.lookup(p);

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -27,9 +27,12 @@ public:
 		return leaf is null ? PageDescriptor(0) : leaf.load();
 	}
 
+	bool map(void* address, size_t size, PageDescriptor pd) shared {
+		return tree.setRange(address, size, pd);
+	}
+
 	bool remap(Extent* extent, ExtentClass ec) shared {
-		return tree
-			.setRange(extent.address, extent.size, PageDescriptor(extent, ec));
+		return map(extent.address, extent.size, PageDescriptor(extent, ec));
 	}
 
 	bool remap(Extent* extent) shared {

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -107,7 +107,7 @@ public:
 		return data >> 60;
 	}
 
-	auto next(uint pages = 1) const {
+	auto next(ulong pages = 1) const {
 		ulong Increment = pages << 60;
 		return PageDescriptor(data + Increment);
 	}

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -232,7 +232,7 @@ unittest ExtentMap {
 	pd = PageDescriptor(e, ec);
 
 	e.at(ptr, 40 * PageSize, null, ec);
-	emap.enlarge(ptr + 5 * PageSize, 35 * PageSize);
+	assert(emap.enlarge(ptr + 5 * PageSize, 35 * PageSize));
 
 	for (auto p = ptr; p < e.address + e.size; p += PageSize) {
 		auto getpd = emap.lookup(p);

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -107,13 +107,8 @@ public:
 		return data >> 60;
 	}
 
-	auto next() const {
-		enum Increment = 1UL << 60;
-		return PageDescriptor(data + Increment);
-	}
-
-	auto addIndex(ulong x) const {
-		auto Increment = (x & 0xf) << 60;
+	auto next(uint pages = 1) const {
+		ulong Increment = pages << 60;
 		return PageDescriptor(data + Increment);
 	}
 

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -112,6 +112,11 @@ public:
 		return PageDescriptor(data + Increment);
 	}
 
+	auto addIndex(ulong x) const {
+		auto Increment = (x & 0xf) << 60;
+		return PageDescriptor(data + Increment);
+	}
+
 	/**
 	 * Arena.
 	 */

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -29,10 +29,7 @@ public:
 
 	bool enlarge(void* address, size_t size) shared {
 		auto lastPd = lookup(address - PageSize);
-
-		if (lastPd.extent is null) {
-			return false;
-		}
+		assert(lastPd.extent !is null, "Nothing mapped at address!");
 
 		return map(address, size, lastPd.next());
 	}

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -107,9 +107,9 @@ public:
 		return data >> 60;
 	}
 
-	auto next(ulong pages = 1) const {
-		ulong Increment = pages << 60;
-		return PageDescriptor(data + Increment);
+	auto next(uint pages = 1) const {
+		ulong increment = cast(ulong) pages << 60;
+		return PageDescriptor(data + increment);
 	}
 
 	/**

--- a/sdlib/d/gc/emap.d
+++ b/sdlib/d/gc/emap.d
@@ -29,7 +29,7 @@ public:
 
 	bool enlarge(void* address, size_t size) shared {
 		auto lastPd = lookup(address - PageSize);
-		assert(lastPd.extent !is null, "Nothing mapped at address!");
+		assert(lastPd.extent !is null, "Nothing mapped before address!");
 
 		return map(address, size, lastPd.next());
 	}

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -447,9 +447,9 @@ unittest getCapacity {
 	assert(p4 is p3);
 	assert(threadCache.getCapacity(p4[0 .. 16000]) == 16384);
 
-	// This one, not:
+	// This one similarly happens in-place:
 	auto p5 = threadCache.realloc(p4, 20000, false);
-	assert(p5 !is p4);
+	assert(p5 is p4);
 	assert(threadCache.getCapacity(p5[0 .. 20000]) == 20480);
 
 	// Realloc from large to small size class results in new allocation:


### PR DESCRIPTION
Resolves https://github.com/snazzy-d/sdc/issues/265 by adding support for growing allocations to `resizeLarge()`.