### PR TITLE
Fixes compilation error: operation not allowed on `bool` `neg`

### DIFF
--- a/src/util/math.d
+++ b/src/util/math.d
@@ -6,7 +6,11 @@ bool isPow2(T)(T x) if (isIntegral!T) {
 	return (x & (x - 1)) == 0;
 }
 
-Signed!T maybeNegate(T)(T value, bool neg) {
+Signed!T maybeNegate(T)(T value, bool _neg) {
+	const neg = cast(int) _neg;
+
+	assert(neg == 0 || neg == 1);
+
 	return (value - neg) ^ -neg;
 }
 


### PR DESCRIPTION
```
sdc/src/util/math.d(10,26): Error: operation not allowed on `bool` `neg`
```
