### PR TITLE
Refactor capacity-handling logic in tcache.

### DIFF
--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -64,8 +64,7 @@ public:
 
 	@property
 	size_t usedCapacity() {
-		// Allocs which do not support metadata have a defined capacity of 0:
-		return _allowsMetaData ? sg.size - freeSpace : 0;
+		return sg.size - freeSpace;
 	}
 
 	bool setUsedCapacity(size_t size) {
@@ -155,7 +154,6 @@ unittest SlabAllocInfo {
 			assert(!si.allowsMetaData);
 			assert(!si.hasMetaData);
 			assert(si.freeSpace == 0);
-			assert(si.usedCapacity == 0);
 			assert(!si.setUsedCapacity(0));
 			assert(!si.setUsedCapacity(1));
 		}

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -431,7 +431,7 @@ unittest getCapacity {
 	auto nonAppendable = threadCache.alloc(50, false);
 	assert(threadCache.getCapacity(nonAppendable[0 .. 0]) == 0);
 	assert(threadCache.getCapacity(nonAppendable[0 .. 50]) == 0);
-	assert(threadCache.getCapacity(nonAppendable[0 .. 56]) == 0);
+	assert(threadCache.getCapacity(nonAppendable[0 .. 56]) == 56);
 
 	// Capacity of any slice in space unknown to the GC is zero:
 	void* nullPtr = null;


### PR DESCRIPTION
Simplify capacity-handling logic in tcache, removing all direct getting/setting of small alloc freespace; unified validator of large/small alloc capacity.