### PR TITLE
Fix currently-inert bug in ptrToAllocEnd.

### DIFF
--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -115,7 +115,7 @@ private:
 
 	@property
 	T* ptrToAllocEnd(T)() {
-		return cast(T*) (sg.address + sg.size) - T.sizeof;
+		return cast(T*) (sg.address + sg.size - T.sizeof);
 	}
 
 	alias freeSpacePtr = ptrToAllocEnd!ushort;


### PR DESCRIPTION
Currently harmless but does prevent this function from correctly working when used with size_t.