### PR TITLE
Slab alloc threadcache

### DIFF
--- a/sdlib/d/gc/arena.d
+++ b/sdlib/d/gc/arena.d
@@ -112,12 +112,13 @@ public:
 	/**
 	 * Small allocation facilities.
 	 */
-	void* allocSmall(shared(ExtentMap)* emap, size_t size) shared {
+	uint allocSmall(shared(ExtentMap)* emap, size_t size,
+	                void*[] allocs) shared {
 		// TODO: in contracts
 		assert(isSmallSize(size));
 
 		auto sizeClass = getSizeClass(size);
-		return bins[sizeClass].alloc(&this, emap, sizeClass);
+		return bins[sizeClass].alloc(&this, emap, sizeClass, allocs);
 	}
 
 	/**

--- a/sdlib/d/gc/dequeue.d
+++ b/sdlib/d/gc/dequeue.d
@@ -1,0 +1,147 @@
+module d.gc.dequeue;
+
+template DEQueue(T, uint Entries) {
+	struct DEQueue {
+	private:
+		uint _front = 0;
+		uint _back = 0;
+		uint _count = 0;
+		T[Entries] _buffer;
+
+	public:
+		enum Size = Entries;
+
+		@property
+		auto buffer() {
+			assert(empty, "Buffer is not empty!");
+
+			return _buffer.ptr;
+		}
+
+		void clear() {
+			_front = 0;
+			_back = 0;
+			_count = 0;
+		}
+
+		void pushBackAdvance(uint delta) {
+			assert(empty, "Cannot pushBackAdvance: not empty!");
+			assert(delta <= Entries,
+			       "Cannot pushBackAdvance: delta exceeds Entries!");
+
+			_front = 0;
+			_back = delta % Entries;
+			_count = delta;
+		}
+
+		void pushBack(T item) {
+			assert(!full, "Cannot pushBack: full!");
+
+			_buffer[_back] = item;
+			_back = (_back + 1) % Entries;
+			_count++;
+		}
+
+		T popFront() {
+			assert(!empty, "Cannot popFront: empty!");
+
+			auto item = _buffer[_front];
+			_front = (_front + 1) % Entries;
+			_count--;
+
+			return item;
+		}
+
+		void pushFront(T item) {
+			assert(!full, "Cannot pushFront: full!");
+
+			_front = (_front > 0 ? _front : Entries) - 1;
+			_buffer[_front] = item;
+			_count++;
+		}
+
+		T popBack() {
+			assert(!empty, "Cannot popBack: empty!");
+
+			_back = (_back > 0 ? _back : Entries) - 1;
+			auto item = _buffer[_back];
+			_count--;
+
+			return item;
+		}
+
+		@property
+		auto length() {
+			return _count;
+		}
+
+		@property
+		bool empty() {
+			return _count == 0;
+		}
+
+		@property
+		bool full() {
+			return _count == Entries;
+		}
+	}
+}
+
+unittest DEQueue {
+	static DEQueue!(uint, 3) q;
+	assert(q.empty);
+
+	q.pushBack(1);
+	q.pushBack(2);
+	q.pushBack(3);
+	assert(q.full);
+	assert(q.popFront() == 1);
+	assert(q.popFront() == 2);
+	assert(q.popFront() == 3);
+	assert(q.empty);
+
+	q.pushBack(1);
+	q.pushBack(2);
+	q.pushBack(3);
+	assert(q.full);
+	assert(q.popBack() == 3);
+	assert(q.popBack() == 2);
+	assert(q.popBack() == 1);
+	assert(q.empty);
+
+	q.pushFront(1);
+	q.pushFront(2);
+	q.pushFront(3);
+	assert(q.full);
+	assert(q.popFront() == 3);
+	assert(q.popFront() == 2);
+	assert(q.popFront() == 1);
+	assert(q.empty);
+
+	q.pushFront(1);
+	q.pushFront(2);
+	q.pushFront(3);
+	assert(q.full);
+	assert(q.popBack() == 1);
+	assert(q.popBack() == 2);
+	assert(q.popBack() == 3);
+	assert(q.empty);
+
+	q.pushBack(1);
+	q.pushFront(2);
+	q.pushBack(3);
+	assert(q.full);
+	assert(q.popFront() == 2);
+	assert(q.popBack() == 3);
+	assert(q.popFront() == 1);
+	assert(q.empty);
+
+	q.pushBack(1);
+	q.pushFront(2);
+	q.pushBack(3);
+	assert(q.full);
+	assert(q.popBack() == 3);
+	assert(q.popFront() == 2);
+	assert(q.popBack() == 1);
+	assert(q.empty);
+}

--- a/sdlib/d/gc/slab.d
+++ b/sdlib/d/gc/slab.d
@@ -76,6 +76,10 @@ public:
 		return true;
 	}
 
+	void clearMetadata() {
+		setFreeSpace(0);
+	}
+
 	@property
 	Finalizer finalizer() {
 		if (!finalizerEnabled) {


### PR DESCRIPTION
This is a **skeleton** of the GC thread cache ( https://github.com/snazzy-d/sdc/issues/269 )

To become useful, it still needs:
- ~Bulk alloc of slab slots in the refiller~ (done)
- Sort on "closest to vacant slab state" prior to eviction when flushing
- Tests.
- Possibly, other corrections.

The cache bins are double-ended queues. The rationale for this:
- We don't want to sort in `getSlot`
- If we intern all returned allocs on the same end we get new ones on, it becomes impossible to guarantee correctness of https://github.com/dsm9000/sdc/blob/master/sdlib/d/gc/tcache.d#L768 , https://github.com/dsm9000/sdc/blob/master/sdlib/d/gc/tcache.d#L740 , and all similar tests. 
- It would be nonsensical and breaking with traditional allocator behaviour for new allocs to "walk backwards" pointerwise.
- Makes the eviction sort (TODO) easier to implement efficiently.