### PR TITLE
Issue diagnostic message if module name mismatches file

### DIFF
--- a/src/d/ast/declaration.d
+++ b/src/d/ast/declaration.d
@@ -92,18 +92,18 @@ final:
 class Module : Declaration {
 	Name name;
 	Name[] packages;
-	Location locationDeclarationName;
+	Location declaredNameLocation;
 
 	Declaration[] declarations;
 
 	this(Location location, Name name, Name[] packages,
-	     Declaration[] declarations, Location locationDeclarationName) {
+	     Location declaredNameLocation, Declaration[] declarations) {
 		super(location);
 
 		this.name = name;
 		this.packages = packages;
+		this.declaredNameLocation = declaredNameLocation;
 		this.declarations = declarations;
-		this.locationDeclarationName = locationDeclarationName;
 	}
 }
 

--- a/src/d/ast/declaration.d
+++ b/src/d/ast/declaration.d
@@ -95,13 +95,16 @@ class Module : Declaration {
 
 	Declaration[] declarations;
 
+	Location locationStatement;
+
 	this(Location location, Name name, Name[] packages,
-	     Declaration[] declarations) {
+	     Declaration[] declarations, Location locationStatement) {
 		super(location);
 
 		this.name = name;
 		this.packages = packages;
 		this.declarations = declarations;
+		this.locationStatement = locationStatement;
 	}
 }
 

--- a/src/d/ast/declaration.d
+++ b/src/d/ast/declaration.d
@@ -95,16 +95,16 @@ class Module : Declaration {
 
 	Declaration[] declarations;
 
-	Location locationStatement;
+	Location locationName;
 
 	this(Location location, Name name, Name[] packages,
-	     Declaration[] declarations, Location locationStatement) {
+	     Declaration[] declarations, Location locationName) {
 		super(location);
 
 		this.name = name;
 		this.packages = packages;
 		this.declarations = declarations;
-		this.locationStatement = locationStatement;
+		this.locationName = locationName;
 	}
 }
 

--- a/src/d/ast/declaration.d
+++ b/src/d/ast/declaration.d
@@ -92,19 +92,18 @@ final:
 class Module : Declaration {
 	Name name;
 	Name[] packages;
+	Location locationDeclarationName;
 
 	Declaration[] declarations;
 
-	Location locationName;
-
 	this(Location location, Name name, Name[] packages,
-	     Declaration[] declarations, Location locationName) {
+	     Declaration[] declarations, Location locationDeclarationName) {
 		super(location);
 
 		this.name = name;
 		this.packages = packages;
 		this.declarations = declarations;
-		this.locationName = locationName;
+		this.locationDeclarationName = locationDeclarationName;
 	}
 }
 

--- a/src/d/parser/dmodule.d
+++ b/src/d/parser/dmodule.d
@@ -17,12 +17,12 @@ auto parseModule(ref TokenRange trange) {
 
 	Name name;
 	Name[] packages;
-	Location locationName;
+	Location declaredNameLocation;
 
 	if (trange.front.type == TokenType.Module) {
 		trange.popFront();
 		name = trange.front.name;
-		locationName = trange.front.location;
+		declaredNameLocation = trange.front.location;
 
 		trange.match(TokenType.Identifier);
 		while (trange.front.type == TokenType.Dot) {
@@ -34,7 +34,7 @@ auto parseModule(ref TokenRange trange) {
 			trange.match(TokenType.Identifier);
 		}
 
-		locationName = locationName.spanTo(trange.previous);
+		declaredNameLocation = declaredNameLocation.spanTo(trange.previous);
 		trange.match(TokenType.Semicolon);
 	}
 
@@ -44,5 +44,5 @@ auto parseModule(ref TokenRange trange) {
 	}
 
 	return new Module(location.spanTo(trange.previous), name, packages,
-	                  declarations, locationName);
+	                  declaredNameLocation, declarations);
 }

--- a/src/d/parser/dmodule.d
+++ b/src/d/parser/dmodule.d
@@ -17,12 +17,12 @@ auto parseModule(ref TokenRange trange) {
 
 	Name name;
 	Name[] packages;
-	Location locationStatement;
+	Location locationName;
 
 	if (trange.front.type == TokenType.Module) {
-		locationStatement = location;
 		trange.popFront();
 		name = trange.front.name;
+		locationName = trange.front.location;
 
 		trange.match(TokenType.Identifier);
 		while (trange.front.type == TokenType.Dot) {
@@ -34,8 +34,8 @@ auto parseModule(ref TokenRange trange) {
 			trange.match(TokenType.Identifier);
 		}
 
+		locationName = locationName.spanTo(trange.previous);
 		trange.match(TokenType.Semicolon);
-		locationStatement = locationStatement.spanTo(trange.previous);
 	}
 
 	Declaration[] declarations;
@@ -44,5 +44,5 @@ auto parseModule(ref TokenRange trange) {
 	}
 
 	return new Module(location.spanTo(trange.previous), name, packages,
-	                  declarations, locationStatement);
+	                  declarations, locationName);
 }

--- a/src/d/parser/dmodule.d
+++ b/src/d/parser/dmodule.d
@@ -17,8 +17,10 @@ auto parseModule(ref TokenRange trange) {
 
 	Name name;
 	Name[] packages;
+	Location locationStatement;
 
 	if (trange.front.type == TokenType.Module) {
+		locationStatement = location;
 		trange.popFront();
 		name = trange.front.name;
 
@@ -33,6 +35,7 @@ auto parseModule(ref TokenRange trange) {
 		}
 
 		trange.match(TokenType.Semicolon);
+		locationStatement = locationStatement.spanTo(trange.previous);
 	}
 
 	Declaration[] declarations;
@@ -41,5 +44,5 @@ auto parseModule(ref TokenRange trange) {
 	}
 
 	return new Module(location.spanTo(trange.previous), name, packages,
-	                  declarations);
+	                  declarations, locationStatement);
 }

--- a/src/d/semantic/dmodule.d
+++ b/src/d/semantic/dmodule.d
@@ -10,7 +10,6 @@ import d.ast.declaration;
 
 import d.ir.symbol;
 
-import source.exception;
 import source.name;
 
 alias AstModule = d.ast.declaration.Module;
@@ -109,11 +108,19 @@ public:
 			m.packages = packages;
 		} else {
 			// We have one; compare it to the file.
-			// XXX: Do proper error checking. Consider doing fixup.
-			if (m.name != name)
-				throw new CompileException(m.locationName, "Module name mismatches filename");
-			if (m.packages != packages)
-				throw new CompileException(m.locationName, "Module package mismatches directory hierarchy");
+			import source.exception;
+
+			if (m.name != name) {
+				throw new CompileException(m.locationDeclarationName,
+				                           "Module name mismatches filename.");
+			}
+
+			if (m.packages != packages) {
+				throw new CompileException(
+					m.locationDeclarationName,
+					"Module package mismatches directory hierarchy."
+				);
+			}
 		}
 
 		return m;

--- a/src/d/semantic/dmodule.d
+++ b/src/d/semantic/dmodule.d
@@ -111,13 +111,13 @@ public:
 			import source.exception;
 
 			if (m.name != name) {
-				throw new CompileException(m.locationDeclarationName,
+				throw new CompileException(m.declaredNameLocation,
 				                           "Module name mismatches filename.");
 			}
 
 			if (m.packages != packages) {
 				throw new CompileException(
-					m.locationDeclarationName,
+					m.declaredNameLocation,
 					"Module package mismatches directory hierarchy."
 				);
 			}

--- a/src/d/semantic/dmodule.d
+++ b/src/d/semantic/dmodule.d
@@ -10,6 +10,7 @@ import d.ast.declaration;
 
 import d.ir.symbol;
 
+import source.exception;
 import source.name;
 
 alias AstModule = d.ast.declaration.Module;
@@ -107,9 +108,12 @@ public:
 			m.name = name;
 			m.packages = packages;
 		} else {
+			// We have one; compare it to the file.
 			// XXX: Do proper error checking. Consider doing fixup.
-			assert(m.name == name, "Wrong module name");
-			assert(m.packages == packages, "Wrong module package");
+			if (m.name != name)
+				throw new CompileException(m.locationStatement, "Module name mismatches filename");
+			if (m.packages != packages)
+				throw new CompileException(m.locationStatement, "Module package mismatches directory hierarchy");
 		}
 
 		return m;

--- a/src/d/semantic/dmodule.d
+++ b/src/d/semantic/dmodule.d
@@ -111,9 +111,9 @@ public:
 			// We have one; compare it to the file.
 			// XXX: Do proper error checking. Consider doing fixup.
 			if (m.name != name)
-				throw new CompileException(m.locationStatement, "Module name mismatches filename");
+				throw new CompileException(m.locationName, "Module name mismatches filename");
 			if (m.packages != packages)
-				throw new CompileException(m.locationStatement, "Module package mismatches directory hierarchy");
+				throw new CompileException(m.locationName, "Module package mismatches directory hierarchy");
 		}
 
 		return m;

--- a/test/invalid/module_name_mismatch.d
+++ b/test/invalid/module_name_mismatch.d
@@ -1,4 +1,4 @@
 //T error: module_name_mismatch.d:4:7:
-//T error: Module name mismatches filename
+//T error: Module name mismatches filename.
 
 module module_name_match;

--- a/test/invalid/module_name_mismatch.d
+++ b/test/invalid/module_name_mismatch.d
@@ -1,0 +1,4 @@
+//T error: module_name_mismatch.d:4:7:
+//T error: Module name mismatches filename
+
+module module_name_match;

--- a/test/invalid/module_package_mismatch.d
+++ b/test/invalid/module_package_mismatch.d
@@ -1,0 +1,4 @@
+//T error: module_package_mismatch.d:4:7:
+//T error: Module package mismatches directory hierarchy.
+
+module invalid.module_package_mismatch;


### PR DESCRIPTION
Currently SDC asserts whether the module name matches filename + file hierarchy, but produces an ICE if this check fails.
How about throwing a `CompileException` carrying the location of the declaration statement?