### PR TITLE
Explicitly convert loop indexes from `size_t` to `uint`

### DIFF
--- a/src/d/llvm/evaluator.d
+++ b/src/d/llvm/evaluator.d
@@ -379,10 +379,9 @@ struct JitRepacker {
 
 		CompileTimeExpression[] elements;
 
-		static if (uint.max < size_t.max)
-			assert(s.fields.length <= uint.max);
 		foreach (size_t idx, f; s.fields) {
 			auto i = cast(uint) idx;
+			assert(i == idx);
 
 			assert(f.index == i, "fields are out of order");
 			auto t = f.type;

--- a/src/d/llvm/evaluator.d
+++ b/src/d/llvm/evaluator.d
@@ -379,7 +379,11 @@ struct JitRepacker {
 
 		CompileTimeExpression[] elements;
 
-		foreach (uint i, f; s.fields) {
+		static if (uint.max < size_t.max)
+			assert(s.fields.length <= uint.max);
+		foreach (size_t idx, f; s.fields) {
+			auto i = cast(uint) idx;
+
 			assert(f.index == i, "fields are out of order");
 			auto t = f.type;
 

--- a/src/d/llvm/expression.d
+++ b/src/d/llvm/expression.d
@@ -439,7 +439,10 @@ struct ExpressionGen {
 
 		auto dg = LLVMGetUndef(TypeGen(pass.pass).visit(type));
 
-		foreach (uint i, c; eCtxs) {
+		static if (uint.max < size_t.max)
+			assert(eCtxs.length <= uint.max);
+		foreach (size_t idx, c; eCtxs) {
+			auto i = cast(uint) idx;
 			auto ctxValue = tCtxs[i].isRef ? addressOf(c) : visit(c);
 			dg = LLVMBuildInsertValue(builder, dg, ctxValue, i, "");
 		}

--- a/src/d/llvm/expression.d
+++ b/src/d/llvm/expression.d
@@ -439,10 +439,10 @@ struct ExpressionGen {
 
 		auto dg = LLVMGetUndef(TypeGen(pass.pass).visit(type));
 
-		static if (uint.max < size_t.max)
-			assert(eCtxs.length <= uint.max);
 		foreach (size_t idx, c; eCtxs) {
 			auto i = cast(uint) idx;
+			assert(i == idx);
+
 			auto ctxValue = tCtxs[i].isRef ? addressOf(c) : visit(c);
 			dg = LLVMBuildInsertValue(builder, dg, ctxValue, i, "");
 		}


### PR DESCRIPTION
Explicitly convert loop indexes from `size_t` to `uint`.

Fixes these deprecation warnings:
```
src/d/llvm/evaluator.d(382): Deprecation: foreach: loop index implicitly converted from `size_t` to `uint`
src/d/llvm/expression.d(442): Deprecation: foreach: loop index implicitly converted from `size_t` to `uint`
```