### PR TITLE
Base.purgeAddressSpace() via madvise()

### DIFF
--- a/sdlib/d/gc/base.d
+++ b/sdlib/d/gc/base.d
@@ -86,6 +86,18 @@ public:
 		return (cast(Base*) &this).reserveAddressSpaceImpl(size, alignment);
 	}
 
+	void purgeAddressSpace(void* address, size_t size) shared {
+		assert(address !is null && isAligned(address, HugePageSize),
+		       "Invalid address!");
+		assert(size > 0 && isAligned(size, HugePageSize), "Invalid size!");
+
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		import d.gc.memmap;
+		pages_purge(address, size);
+	}
+
 private:
 	void clearImpl() {
 		assert(mutex.isHeld(), "Mutex not held!");

--- a/sdlib/d/gc/memmap.d
+++ b/sdlib/d/gc/memmap.d
@@ -68,6 +68,11 @@ void pages_unmap(void* addr, size_t size) {
 	assert(ret != -1, "munmap failed!");
 }
 
+void pages_purge(void* addr, size_t size) {
+	auto ret = madvise(addr, size, Advise.Purge);
+	assert(ret == 0, "madvise failed!");
+}
+
 private:
 
 enum PagesFDTag = -1;

--- a/sdlib/sys/mman.d
+++ b/sdlib/sys/mman.d
@@ -11,12 +11,20 @@ enum Prot {
 	Exec = 0x4,
 }
 
+// TODO: confirm platform-specific values
+enum MADV_DONTNEED = 4;
+enum MADV_FREE = 8;
+
 version(OSX) {
 	enum Map {
 		Shared = 0x01,
 		Private = 0x02,
 		Fixed = 0x10,
 		Anon = 0x1000,
+	}
+
+	enum Advise {
+		Purge = MADV_DONTNEED
 	}
 }
 
@@ -27,6 +35,10 @@ version(FreeBSD) {
 		Fixed = 0x10,
 		Anon = 0x1000,
 	}
+
+	enum Advise {
+		Purge = MADV_DONTNEED
+	}
 }
 
 version(linux) {
@@ -36,9 +48,14 @@ version(linux) {
 		Fixed = 0x10,
 		Anon = 0x20,
 	}
+
+	enum Advise {
+		Purge = MADV_FREE
+	}
 }
 
 extern(C):
 void* mmap(void* addr, size_t length, int prot, int flags, int fd,
            off_t offset);
 int munmap(void* addr, size_t length);
+int madvise(void* addr, size_t length, int advice);


### PR DESCRIPTION
Split from https://github.com/snazzy-d/sdc/pull/335 , but does not depend on it.

This feature permits the purging of an arbitrary run of _dirty_ pages, rendering it _clean_, as requested in https://github.com/snazzy-d/sdc/issues/270 .

Uses the "lazy" `madvise` operation `MADV_FREE` on Linux (where supported) and the equiv. but eager `MADV_DONTNEED` operation on all other supported platforms.

AFAIK not feasible to unit test, as the OS provides no immediate confirmation of the effects of `madvise`.

Required by https://github.com/snazzy-d/sdc/pull/337 .