### PR TITLE
Separate new-syntax contracts with linebreaks

### DIFF
--- a/src/format/parser.d
+++ b/src/format/parser.d
@@ -2423,6 +2423,7 @@ private:
 
 	bool parseFunctionPostfix() {
 		auto guard = span!IndentSpan(2);
+		int nNewSyntaxContracts = 0;
 
 		while (true) {
 			clearSeparator();
@@ -2445,6 +2446,11 @@ private:
 					if (lookahead.front.type == OpenBrace) {
 						nextToken();
 						goto ContractBlock;
+					} else {
+						++nNewSyntaxContracts;
+						if (nNewSyntaxContracts > 1) {
+							newline();
+						}
 					}
 
 					split();
@@ -2459,6 +2465,11 @@ private:
 					if (lookahead.front.type == OpenBrace) {
 						nextToken();
 						goto ContractBlock;
+					} else {
+						++nNewSyntaxContracts;
+						if (nNewSyntaxContracts > 1) {
+							newline();
+						}
 					}
 
 					split();

--- a/src/format/span.d
+++ b/src/format/span.d
@@ -344,11 +344,9 @@ final class ListSpan : Span {
 		headerSplit = i;
 	}
 
-	void registerTrailingSplit(size_t i) in {
-		assert(elements.length > 0);
-		assert(elements[$ - 1] <= i);
-		assert(!hasTrailingSplit);
-	} do {
+	void registerTrailingSplit(size_t i) in(elements.length > 0)
+			in(elements[$ - 1] <= i)
+			in(!hasTrailingSplit) {
 		trailingSplit = i;
 
 		if (elements.length > 1) {

--- a/src/format/span.d
+++ b/src/format/span.d
@@ -330,10 +330,9 @@ final class ListSpan : Span {
 		return trailingSplit != size_t.max;
 	}
 
-	void registerElement(size_t i) in {
-		assert(elements.length == 0 || elements[$ - 1] <= i);
-		assert(!hasTrailingSplit);
-	} do {
+	void registerElement(size_t i)
+			in(elements.length == 0 || elements[$ - 1] <= i)
+			in(!hasTrailingSplit) {
 		import std.algorithm;
 		headerSplit = min(i, headerSplit);
 


### PR DESCRIPTION
Separate new-syntax contracts with linebreaks.
Implements #331 in a mostly unintrusive way (as far as I can tell).