### PR TITLE
Static print buffer for d.rt.contract.

### DIFF
--- a/sdlib/core/stdc/stdio.d
+++ b/sdlib/core/stdc/stdio.d
@@ -1,5 +1,17 @@
 module core.stdc.stdio;
 
+enum DbgPrintBufferSize = 4096;
+
+static char[DbgPrintBufferSize] _dbgPrintBuffer;
+
+void printDebug() {
+	dbgprint(_dbgPrintBuffer.ptr);
+}
+
+void dbgprint(char* str) {
+	write(2, str, strnlen(str, DbgPrintBufferSize));
+}
+
 extern(C):
 
 // @trusted: // Types only.
@@ -8,3 +20,6 @@ extern(C):
 
 int printf(const char* fmt, ...);
 int puts(const char* s);
+int snprintf(char* dest, size_t size, const char* fmt, ...);
+int write(int fd, const char* buf, int count);
+int strnlen(char* str, size_t maxlen);

--- a/sdlib/d/rt/contract.d
+++ b/sdlib/d/rt/contract.d
@@ -4,12 +4,16 @@ extern(C):
 
 void __sd_assert_fail(string file, int line) {
 	import core.stdc.stdlib, core.stdc.stdio;
-	printf("assert fail: %s:%d\n", file.ptr, line);
+	snprintf(_dbgPrintBuffer.ptr, DbgPrintBufferSize, "assert fail: %s:%d\n",
+	         file.ptr, line);
+	printDebug();
 	exit(1);
 }
 
 void __sd_assert_fail_msg(string msg, string file, int line) {
 	import core.stdc.stdlib, core.stdc.stdio;
-	printf("%s: %s:%d\n", msg.ptr, file.ptr, line);
+	snprintf(_dbgPrintBuffer.ptr, DbgPrintBufferSize, "%s: %s:%d\n", msg.ptr,
+	         file.ptr, line);
+	printDebug();
 	exit(1);
 }


### PR DESCRIPTION
Fixes the annoyance where `assert()` will not print from inside GC on account of the use of dynamically-allocated buffers.