### PR TITLE
There is now a dub.selections.json file checked in.

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,5 @@
+{
+	"fileVersion": 1,
+	"versions": {
+	}
+}


### PR DESCRIPTION
This works around an apparent dub bug (not yet triaged) that meant people consuming sdfmt via `dub run sdc:sdfmt` were ending up relinking sdfmt on every run - dub insists on rebuilding if it doesn't see a lockfile.

sdc has no dependencies from the dub registry
so this should not really be required but alas.