### PR TITLE
sdfmt: Support stdin input and `--assume-filename` option

### DIFF
--- a/test/runner/checkformat.d
+++ b/test/runner/checkformat.d
@@ -9,6 +9,7 @@ import util;
 
 immutable SDFMT = "bin/sdfmt";
 
+// tests a file on disk
 struct Task {
 	string name;
 	string formatter;
@@ -20,25 +21,57 @@ struct Task {
 		import std.process;
 		auto result = execute([formatter, name]);
 
-		import std.stdio;
-		if (result.status != 0) {
-			stderr.writefln("%s: sdfmt expected to format, did not (%d).", name,
-			                result.status);
-			return TestResult(name, false, true);
-		}
-
-		import std.encoding;
-		auto bom = getBOM(cast(const(ubyte)[]) original).schema;
-		if (bom == BOM.none && result.output != original) {
-			stderr.writefln("%s: sdfmt did not format as expected.", name);
-			return TestResult(name, false, true);
-		}
-
-		return TestResult(name, true, true);
+		return check(name, original, result.status, result.output);
 	}
 }
 
-struct CheckFormat {
+// tests a file by passing its contents manually in stdin (and specifying the original path via --assume-filename)
+struct StdinTask {
+	string name;
+	string formatter;
+
+	TestResult run() {
+		import std.file;
+		string original = cast(string) read(name);
+
+		import std.process;
+		auto pipes = pipeProcess(
+			[formatter, "--assume-filename", name],
+			Redirect.stdin | Redirect.stdout | Redirect.stderrToStdout
+		);
+
+		pipes.stdin.write(original);
+		pipes.stdin.close();
+
+		const status = pipes.pid.wait;
+
+		import std.array;
+		const output = cast(string) pipes.stdout.byChunk(4096).join;
+
+		return check(name, original, status, output);
+	}
+}
+
+private TestResult check(string filename, string originalData,
+                         int processStatus, string processOutput) {
+	import std.stdio;
+	if (processStatus != 0) {
+		stderr.writefln("%s: sdfmt expected to format, did not (%d).", filename,
+		                processStatus);
+		return TestResult(filename, false, true);
+	}
+
+	import std.encoding;
+	auto bom = getBOM(cast(const(ubyte)[]) originalData).schema;
+	if (bom == BOM.none && processOutput != originalData) {
+		stderr.writefln("%s: sdfmt did not format as expected.", filename);
+		return TestResult(filename, false, true);
+	}
+
+	return TestResult(filename, true, true);
+}
+
+struct CheckFormat(TaskType) {
 	enum Name = "Formatter Test Runner";
 	enum XtraDoc = "specific test";
 
@@ -62,10 +95,14 @@ struct CheckFormat {
 			"test/compilable", "test/format", "test/invalid", "test/runner",
 			"test/unit", "test/valid", "sdlib/d", "src",
 		].map!(d => dirEntries(d, "*.d", SpanMode.breadth)).join()
-		 .filter!(f => f.isFile()).map!(t => Task(t, formatter));
+		 .filter!(f => f.isFile()).map!(t => TaskType(t, formatter));
 	}
 }
 
 int main(string[] args) {
-	return runUtility(CheckFormat(), args);
+	// 2 passes: from disk first, then (if successful) via stdin
+	if (const diskStatus = runUtility(CheckFormat!Task(), args))
+		return diskStatus;
+	const stdinStatus = runUtility(CheckFormat!StdinTask(), args);
+	return stdinStatus;
 }


### PR DESCRIPTION
Implementing #262.

The only thing I've tested is this: `echo "module  abc;" | bin/sdfmt -`, which did output the expected `module abc;` (extra space removed) to stdout. ;)