### PR TITLE
Fill out  roots API

### DIFF
--- a/sdlib/d/gc/capi.d
+++ b/sdlib/d/gc/capi.d
@@ -78,11 +78,6 @@ void __sd_gc_add_roots(const void[] range) {
 	gState.addRoots(range);
 }
 
-void __sd_gc_add_roots_ptr(const void* ptr, size_t length) {
-	import d.gc.global;
-	gState.addRoots(ptr[0 .. length]);
-}
-
 void __sd_gc_remove_roots(const void* ptr) {
 	import d.gc.global;
 	gState.removeRoots(ptr);

--- a/sdlib/d/gc/capi.d
+++ b/sdlib/d/gc/capi.d
@@ -78,6 +78,16 @@ void __sd_gc_add_roots(const void[] range) {
 	gState.addRoots(range);
 }
 
+void __sd_gc_add_roots_ptr(const void* ptr, size_t length) {
+	import d.gc.global;
+	gState.addRoots(ptr[0 .. length]);
+}
+
+void __sd_gc_remove_roots(const void* ptr) {
+	import d.gc.global;
+	gState.removeRoots(ptr);
+}
+
 void __sd_gc_add_tls_segment(const void[] range) {
 	threadCache.addTLSSegment(range);
 }

--- a/sdlib/d/gc/global.d
+++ b/sdlib/d/gc/global.d
@@ -25,6 +25,13 @@ public:
 		(cast(GCState*) &this).addRootsImpl(range);
 	}
 
+	void removeRoots(const void* ptr) shared {
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		(cast(GCState*) &this).removeRootsImpl(ptr);
+	}
+
 	void scanRoots(ScanDg scan) shared {
 		mutex.lock();
 		scope(exit) mutex.unlock();
@@ -46,14 +53,42 @@ private:
 		roots = (cast(const(void*)[]*) ptr)[0 .. length];
 
 		import d.gc.range;
-		roots[index] = makeRange(range);
+		if (range.length == 0) {
+			roots[index] = cast(void*[]) range;
+		} else {
+			roots[index] = makeRange(range);
+		}
+	}
+
+	void removeRootsImpl(const void* ptr) {
+		assert(mutex.isHeld(), "Mutex not held!");
+
+		// Search in reverse, since it's most likely for things to be removed
+		// in the reverse order they were added.
+		foreach_reverse (i; 0 .. roots.length) {
+			if (cast(void*) roots[i].ptr == ptr) {
+				auto length = roots.length - 1;
+				roots[i] = roots[length];
+				import d.gc.tcache;
+				auto newRoots = threadCache
+					.realloc(roots.ptr, length * void*[].sizeof, true);
+				roots = (cast(const(void*)[]*) newRoots)[0 .. length];
+				return;
+			}
+		}
 	}
 
 	void scanRootsImpl(ScanDg scan) {
 		assert(mutex.isHeld(), "Mutex not held!");
 
 		foreach (range; roots) {
-			scan(range);
+			// Adding a range of length 0 is like pinning the given range
+			// address. This is scanned when the roots array itself is scanned
+			// (because it's referred to from the global segment). Therefore,
+			// we can skip the marking of that pointer.
+			if (range.length > 0) {
+				scan(range);
+			}
 		}
 	}
 }

--- a/sdlib/d/gc/global.d
+++ b/sdlib/d/gc/global.d
@@ -18,7 +18,7 @@ public:
 		return (c + 1) & ubyte.max;
 	}
 
-    /**
+	/**
      * Add a block of scannable data as a root to possible GC memory. This
      * range will be scanned on proper alignment boundaries if it potentially
      * could contain pointers.
@@ -35,7 +35,7 @@ public:
 		(cast(GCState*) &this).addRootsImpl(range);
 	}
 
-    /**
+	/**
      * Remove the root (if present) that begins with the given pointer.
      */
 	void removeRoots(const void* ptr) shared {
@@ -84,6 +84,7 @@ private:
 			if (cast(void*) roots[i].ptr == ptr) {
 				auto length = roots.length - 1;
 				roots[i] = roots[length];
+				roots[length] = [];
 				import d.gc.tcache;
 				auto newRoots = threadCache
 					.realloc(roots.ptr, length * void*[].sizeof, true);

--- a/sdlib/d/gc/global.d
+++ b/sdlib/d/gc/global.d
@@ -18,6 +18,16 @@ public:
 		return (c + 1) & ubyte.max;
 	}
 
+    /**
+     * Add a block of scannable data as a root to possible GC memory. This
+     * range will be scanned on proper alignment boundaries if it potentially
+     * could contain pointers.
+     *
+     * If it has a length of 0, then the range is added as-is, to allow pinning
+     * of GC blocks. These blocks will be scanned as part of the normal
+     * process, by virtue of the pointer being stored as a range of 0 bytes in
+     * the global array of roots.
+     */
 	void addRoots(const void[] range) shared {
 		mutex.lock();
 		scope(exit) mutex.unlock();
@@ -25,6 +35,9 @@ public:
 		(cast(GCState*) &this).addRootsImpl(range);
 	}
 
+    /**
+     * Remove the root (if present) that begins with the given pointer.
+     */
 	void removeRoots(const void* ptr) shared {
 		mutex.lock();
 		scope(exit) mutex.unlock();
@@ -63,8 +76,10 @@ private:
 	void removeRootsImpl(const void* ptr) {
 		assert(mutex.isHeld(), "Mutex not held!");
 
-		// Search in reverse, since it's most likely for things to be removed
-		// in the reverse order they were added.
+		/*
+         * Search in reverse, since it's most likely for things to be removed
+         * in the reverse order they were added.
+         */
 		foreach_reverse (i; 0 .. roots.length) {
 			if (cast(void*) roots[i].ptr == ptr) {
 				auto length = roots.length - 1;
@@ -82,10 +97,12 @@ private:
 		assert(mutex.isHeld(), "Mutex not held!");
 
 		foreach (range; roots) {
-			// Adding a range of length 0 is like pinning the given range
-			// address. This is scanned when the roots array itself is scanned
-			// (because it's referred to from the global segment). Therefore,
-			// we can skip the marking of that pointer.
+			/*
+             * Adding a range of length 0 is like pinning the given range
+             * address. This is scanned when the roots array itself is scanned
+             * (because it's referred to from the global segment). Therefore,
+             * we can skip the marking of that pointer.
+             */
 			if (range.length > 0) {
 				scan(range);
 			}

--- a/sdlib/dmd/thread.d
+++ b/sdlib/dmd/thread.d
@@ -22,8 +22,15 @@ void __sd_scanAllThreadsFn(ScanDg* context, void* start, void* end) {
 
 // sdrt API.
 void __sd_thread_scan(ScanDg scan) {
-	// When druntime is being used, all thread scanning is done by
-	// thread_scanAll_C, and not via SDC's thread scanning.
+	/**
+	 * Note, this is needed, even though druntime will pass in the thread
+	 * stacks to scan. The thread calling the collect will have its stack
+	 * passed in and added to the worklist (see scanner.d), but by the time the
+	 * stack is scanned, it may no longer have the saved registers. Therefore,
+	 * we need to scan the registers now.
+	 */
+	import d.rt.stack;
+	__sd_stack_scan(scan);
 }
 
 void __sd_global_scan(ScanDg scan) {

--- a/test/valid/test0199.d
+++ b/test/valid/test0199.d
@@ -1,0 +1,52 @@
+//T compiles:yes
+//T has-passed:yes
+//T retval:0
+// GC add/remove single root
+
+extern(C) void __sd_gc_collect();
+extern(C) void* __sd_gc_alloc_finalizer(size_t size, void* finalizer);
+extern(C) void* __sd_gc_tl_flush_cache();
+
+int finalizerCalled;
+
+void finalize(void* ptr, size_t size) {
+	++finalizerCalled;
+}
+
+size_t allocate(bool pin) {
+	auto ptr = __sd_gc_alloc_finalizer(16, &finalize);
+	size_t retval = ~cast(size_t) ptr;
+
+	if (pin) {
+		import d.gc.global;
+		gState.addRoots(ptr[0 .. 0]);
+	}
+
+	ptr = null;
+	return retval;
+}
+
+void unpin(size_t blk) {
+	import d.gc.global;
+	gState.removeRoots(cast(void*) ~blk);
+}
+
+void main() {
+	// NOTE: the first slab block allocated is never collected, because it
+	// appears on the stack during collection. Until this bug is fixed, consume
+	// the first allocation.
+	auto ptr = __sd_gc_alloc_finalizer(16, null);
+
+	auto blk = allocate(false);
+	__sd_gc_tl_flush_cache();
+	__sd_gc_collect();
+	assert(finalizerCalled == 1, "Finalizer not called when unpinned.");
+	blk = allocate(true);
+	__sd_gc_tl_flush_cache();
+	__sd_gc_collect();
+	assert(finalizerCalled == 1, "Finalizer called when pinned.");
+	unpin(blk);
+	__sd_gc_tl_flush_cache();
+	__sd_gc_collect();
+	assert(finalizerCalled == 2, "Finalizer not called after unpinning.");
+}


### PR DESCRIPTION
Druntime needs the ability to add and remove roots/ranges. This covers those use cases.

1. If you want to add a root (which is essentially just pinning a GC block), then allow adding a root "range" that is of 0 length. This will be scanned when the roots array is scanned.
2. We need to support adding roots via pointer/length instead of array, since the DMD ABI does not match SDC.
3. We need the ability to remove roots (this should probably be some tree structure, but for now it's a linear search for the existing root).
4. Fix the scanning of global roots from druntime, which was previously not done.
5. Remove calling of SDRT's thread scan, which is not how druntime scans thread stacks.

Not sure if there needs to be a test for this, as it's mostly focused on druntime integration.