### PR TITLE
Add specialized allocation functions for when a new piece of memory

### DIFF
--- a/sdlib/dmd/gc.d
+++ b/sdlib/dmd/gc.d
@@ -108,3 +108,11 @@ bool __sd_gc_set_array_used(void* ptr, PageDescriptor pd, size_t newUsed,
 
 	return true;
 }
+
+void* __sd_gc_alloc_no_pointers(size_t size) {
+	return threadCache.alloc(size, false, false);
+}
+
+void* __sd_gc_alloc_finalizer_no_pointers(size_t size, void* finalizer) {
+	return threadCache.allocAppendable(size, false, false, finalizer);
+}


### PR DESCRIPTION
should not be scanned.

Note that this asks for zero pages when the block contains pointers, which it did not previously.