### PR TITLE
Add resize function.

### DIFF
--- a/sdlib/dmd/gc.d
+++ b/sdlib/dmd/gc.d
@@ -116,3 +116,7 @@ void* __sd_gc_alloc_no_pointers(size_t size) {
 void* __sd_gc_alloc_finalizer_no_pointers(size_t size, void* finalizer) {
 	return threadCache.allocAppendable(size, false, false, finalizer);
 }
+
+size_t __sd_gc_resize(void* ptr, size_t request) {
+	return threadCache.resize(ptr, request);
+}


### PR DESCRIPTION
The resize function will resize an allocation in-place, or return 0. Unlike realloc, it is not allowed to copy data to a new place. Unlike extend, it does not alter the used size, nor does it require a valid slice to do so. Because it never changes the address, nor changes the used size, it can be done without these requirements.

The return value is the resulting capacity of the given block. If any "used" capacity is present, it will be preserved. Shrinking is always allowed, and may or may not free extra pages (used size comes into play here).

This is for use in druntime to extend large allocations into subsequent pages. Currently, we realloc when this happens, which is hugely wasteful.