### PR TITLE
Only scan used capacity on large allocations.

### DIFF
--- a/sdlib/d/gc/scanner.d
+++ b/sdlib/d/gc/scanner.d
@@ -418,16 +418,15 @@ private:
 			}
 		}
 
-		if (pd.containsPointers) {
-			splitAndAddToWorklist(makeRange(e.address, e.address + e.size));
+		if (pd.containsPointers && e.usedCapacity >= PointerSize) {
+			splitAndAddToWorklist(
+				makeRange(e.address, e.address + e.usedCapacity));
 		}
 	}
 
 	void splitAndAddToWorklist(const(void*)[] range) {
 		assert(isAligned(range.ptr, PageSize),
 		       "Range is not aligned properly!");
-		assert(isAligned(range.length, PointerInPage),
-		       "Range has invalid size!");
 		assert(range.length > 0, "Cannot add empty range to the worklist!");
 
 		// In order to expose some parallelism, we split the range


### PR DESCRIPTION
This will save time on scanning, and also remove any need to zero out any tail of allocations.

For a large buffer that is reset to contain very few elements, this will be a huge savings.