### PR TITLE
Reduce reallocs of the worklist

### DIFF
--- a/sdlib/d/gc/scanner.d
+++ b/sdlib/d/gc/scanner.d
@@ -224,7 +224,7 @@ uint getWorkItems(const(void*)[] range) {
 }
 
 const(void*)[] extractWork(ref const(void*)[] range) {
-	assert(range.length > WorkUnit);
+	assert(range.length >= WorkUnit * 2);
 	scope(exit) range = range[WorkUnit .. range.length];
 	return range[0 .. WorkUnit];
 }


### PR DESCRIPTION
For a large range (like 100MB), instead of allocating an array of 1500+ range elements, store one range with the whole thing, and split off pieces of it for each thread that wants a piece.
