### PR TITLE
Zero slabs when collecting if they contain pointers.

### DIFF
--- a/sdlib/d/gc/bitmap.d
+++ b/sdlib/d/gc/bitmap.d
@@ -156,15 +156,25 @@ public:
 	}
 
 	bool nextFreeRange(uint start, ref uint index, ref uint length) const {
+		return nextRange!false(start, index, length);
+	}
+
+	bool nextOccupiedRange(uint start, ref uint index, ref uint length) const {
+		return nextRange!true(start, index, length);
+	}
+
+	bool nextRange(bool V)(uint start, ref uint index, ref uint length) const {
 		// FIXME: in contract.
 		assert(start < N);
 
-		auto i = findClear(start);
+		enum NotV = !V;
+
+		auto i = findValue!V(start);
 		if (i >= N) {
 			return false;
 		}
 
-		auto j = findSet(i);
+		auto j = findValue!NotV(i);
 		index = i;
 		length = j - i;
 		return true;


### PR DESCRIPTION
Split out of collection slab zeroing from #395 

This version uses Bitmap to find ranges of set bits that have been freed, to call memset on larger ranges.

When collecting, for instance, a large graph of nodes, it's very likely there are a bunch of newly-freed slots that can be cleared at once.