### PR TITLE
Always terminate helper thread when testing suspend.

### DIFF
--- a/sdlib/d/gc/tstate.d
+++ b/sdlib/d/gc/tstate.d
@@ -255,6 +255,13 @@ unittest suspend {
 
 	auto autoResumeThreadID = runThread(autoResume);
 
+	scope(exit) {
+		mustStop.store(1);
+
+		void* ret;
+		pthread_join(autoResumeThreadID, &ret);
+	}
+
 	void check(SuspendState ss, bool busy, uint suspendCount) {
 		assert(s.suspendState == ss);
 		assert(s.busy == busy);
@@ -287,9 +294,4 @@ unittest suspend {
 
 	assert(s.exitBusyState());
 	check(SuspendState.None, false, 2);
-
-	mustStop.store(1);
-
-	void* ret;
-	pthread_join(autoResumeThreadID, &ret);
 }


### PR DESCRIPTION
While working on #399, I found that a failed unit test here resulted in a segfault.

What happens is the assert exits the test, without stopping the helper thread. Then the stack is now gone, and the helper thread is using unallocated memory.

Segfaults in sdunit are hard to diagnose because gdb doesn't have any clue what the call stack means.