### PR TITLE
Fix hangs where a lock is held by a suspended thread.

### DIFF
--- a/sdlib/d/gc/collector.d
+++ b/sdlib/d/gc/collector.d
@@ -41,7 +41,6 @@ private:
 
 		import d.gc.thread;
 		stopTheWorld();
-		scope(exit) restartTheWorld();
 
 		import d.gc.global;
 		auto gcCycle = gState.nextGCCycle();
@@ -65,13 +64,15 @@ private:
 		 * We might have allocated, and therefore refilled the bin
 		 * during the collection process. As a result, slots in the
 		 * bins may not be marked at this point.
-		 * 
+		 *
 		 * The straightforward way to handle this is simply to flush
 		 * the bins.
-		 * 
+		 *
 		 * Alternatively, we could make sure the slots are marked.
 		 */
 		threadCache.flush();
+
+		restartTheWorld();
 
 		collect(gcCycle);
 
@@ -82,6 +83,9 @@ private:
 		 * phase.
 		 */
 		gState.minimizeRoots();
+
+		// allow threads to do busyState things.
+		clearWorldProbation();
 	}
 
 	void prepareGCCycle() {

--- a/sdlib/d/gc/collector.d
+++ b/sdlib/d/gc/collector.d
@@ -64,10 +64,10 @@ private:
 		 * We might have allocated, and therefore refilled the bin
 		 * during the collection process. As a result, slots in the
 		 * bins may not be marked at this point.
-		 *
+		 * 
 		 * The straightforward way to handle this is simply to flush
 		 * the bins.
-		 *
+		 * 
 		 * Alternatively, we could make sure the slots are marked.
 		 */
 		threadCache.flush();
@@ -84,7 +84,7 @@ private:
 		 */
 		gState.minimizeRoots();
 
-		// allow threads to do busyState things.
+		// Probation period is over, threads can enter busy state now.
 		clearWorldProbation();
 	}
 

--- a/test/valid/test0203.d
+++ b/test/valid/test0203.d
@@ -1,0 +1,86 @@
+//T compiles:yes
+//T has-passed:yes
+//T retval:0
+// GC multithreaded collection deadlock test
+
+import core.stdc.unistd;
+import core.stdc.pthread;
+import d.sync.atomic;
+import d.sync.mutex;
+
+extern(C) void __sd_gc_collect();
+extern(C) void* __sd_gc_alloc_finalizer(size_t size, void* finalizer);
+
+shared Atomic!uint shouldQuit;
+
+shared Mutex mtx;
+
+shared size_t ndestroyed;
+
+struct S {
+	~this() {
+		mtx.lock();
+		scope(exit) mtx.unlock();
+		ndestroyed += 1;
+	}
+}
+
+void* runThread(void* ctx) {
+	size_t count;
+	while (!shouldQuit.load()) {
+		S s;
+		++count;
+	}
+
+	return cast(void*) count;
+}
+
+void destroyItem(T)(void* item, size_t size) {
+	assert(size == T.sizeof);
+	(cast(T*) item).__dtor();
+}
+
+void allocateItem(T)() {
+	auto ptr = __sd_gc_alloc_finalizer(T.sizeof, &destroyItem!T);
+}
+
+void* watchdog(void* ctx) {
+	import d.gc.tcache;
+	import d.gc.tstate;
+	// TODO: there should be an API for this.
+	threadCache.state.state.store(SuspendState.Detached);
+	int i;
+	while (!shouldQuit.load()) {
+		// Watchdog timeout!
+		assert(++i < 5, "Watchdog timeout!");
+		sleep(1);
+	}
+
+	return null;
+}
+
+void main() {
+	pthread_t[5] tids;
+	pthread_create(&tids[0], null, watchdog, null);
+	// Give the watchdog time to detach.
+	sleep(1);
+	foreach (i; 1 .. 5) {
+		pthread_create(&tids[i], null, runThread, null);
+	}
+
+	foreach (i; 0 .. 100) {
+		allocateItem!S();
+		__sd_gc_collect();
+	}
+
+	shouldQuit.store(1);
+	void* ret;
+	size_t total = 0;
+	foreach (i; 0 .. 5) {
+		pthread_join(tids[i], &ret);
+		total += cast(size_t) ret;
+	}
+
+	// Simple sanity check.
+	assert(ndestroyed > total && ndestroyed <= total + 100);
+}

--- a/test/valid/test0203.d
+++ b/test/valid/test0203.d
@@ -51,8 +51,7 @@ void* watchdog(void* ctx) {
 	threadCache.state.state.store(SuspendState.Detached);
 	int i;
 	while (!shouldQuit.load()) {
-		// Watchdog timeout!
-		assert(++i < 5, "Watchdog timeout!");
+		assert(++i < 15, "Watchdog timeout!");
 		sleep(1);
 	}
 


### PR DESCRIPTION
The sequence this protects against:

1. thread A acquires a lock
2. thread B starts a collection, stops the world
3. thread A is suspended with the lock held
4. thread B runs mark phase, and during collect phase, runs a finalizer
5. finalizer attempts to acquire the lock held by thread A
6. deadlock

This fixes the problem by allowing the world to resume during the collect phase. In order to prevent changes to the GC state which is fully marked, but not yet collected, this introduces a "Probation" mode of the thread state. The probation mode is like the run mode, but if a thread in this mode attempts to enter a busy state, it is paused until the collection thread is finished.

Please closely review if the logic is sound that entering a busy state is the only way to cause problems.

To avoid using signals, which are very error prone, we use a mutex/condition instead.

A new mode must be introduced, because when I tried to do it by just leaving the thread in the "Resumed" mode, I found there was a signaling race condition.