### PR TITLE
Fix roots mechanism to avoid deadlocks and asserts

### DIFF
--- a/sdlib/d/gc/collector.d
+++ b/sdlib/d/gc/collector.d
@@ -74,6 +74,14 @@ private:
 		threadCache.flush();
 
 		collect(gcCycle);
+
+		/**
+		 * Removing roots cannot realloc while inside a finalizer,
+		 * because that could cause a deadlock. So we must periodically
+		 * minimize the roots array, never when inside the collect
+		 * phase.
+		 */
+		gState.minimizeRoots();
 	}
 
 	void prepareGCCycle() {


### PR DESCRIPTION
When roots are removed, avoid using allocations.

This allows the removeRoots function to be used in finalizers, a common place to use them, since this is where you may want to unpin memory, or free externally allocated memory that you then want to unregister.

When roots are added, we should be OK, because you shouldn't be adding roots in a finalizer.

The issue with allocating in a finalizer is that the current arena is locked, and allocating may try to lock the arena again.