### PR TITLE
Create threadpool for GC parallel tasks

### DIFF
--- a/sdlib/d/gc/scanner.d
+++ b/sdlib/d/gc/scanner.d
@@ -55,22 +55,35 @@ public:
 		auto threadCount = activeThreads - 1;
 		auto threadsPtr =
 			cast(pthread_t*) alloca(pthread_t.sizeof * threadCount);
-
 		auto threads = threadsPtr[0 .. threadCount];
-		import d.gc.threadpool;
-		shared ThreadPool threadPool;
-		threadPool.startThreads(threads);
+
+		static void* markThreadEntry(void* ctx) {
+			import d.gc.tcache;
+			threadCache.activateGC(false);
+
+			(cast(shared(Scanner*)) ctx).runMark();
+			return null;
+		}
+
+		// First thing, start the worker threads, so they can do work ASAP.
+		foreach (ref tid; threads) {
+			pthread_create(&tid, null, markThreadEntry, cast(void*) &this);
+		}
 
 		// Scan the roots.
 		__sd_gc_global_scan(addToWorkList);
 
-		threadPool.dispatch(runMark, activeThreads, true);
+		// Now send this thread marking!
+		runMark();
 
-		threadPool.joinAll();
-
-		// We now are done, we can free the worklist.
+		// We now done, we can free the worklist.
 		import d.gc.tcache;
 		threadCache.free(cast(void*) worklist.ptr);
+
+		foreach (tid; threads) {
+			void* ret;
+			pthread_join(tid, &ret);
+		}
 	}
 
 	void addToWorkList(WorkItem[] items) shared {
@@ -105,11 +118,7 @@ public:
 	}
 
 private:
-	void runMark(uint idx) shared {
-		import d.gc.tcache;
-		// Note: in the main thrad, the GC will be reactivated later,
-		// so it is always safe to do this here.
-		threadCache.activateGC(false);
+	void runMark() shared {
 		auto worker = Worker(&this);
 
 		/**

--- a/sdlib/d/gc/thread.d
+++ b/sdlib/d/gc/thread.d
@@ -78,6 +78,10 @@ void restartTheWorld() {
 	gThreadState.restartTheWorld();
 }
 
+void detachSelf() {
+	threadCache.state.detach();
+}
+
 void threadScan(ScanDg scan) {
 	// Scan the registered TLS segments.
 	foreach (s; threadCache.tlsSegments) {
@@ -263,7 +267,7 @@ private:
 			if (count > 32 && ss == SuspendState.Signaled) {
 				import d.gc.proc;
 				if (isDetached(tc.tid)) {
-					tc.state.detach();
+					tc.state.assumeDetached();
 					continue;
 				}
 			}

--- a/sdlib/d/gc/threadpool.d
+++ b/sdlib/d/gc/threadpool.d
@@ -1,0 +1,196 @@
+module d.gc.threadpool;
+
+struct ThreadPool {
+private:
+	import d.sync.mutex;
+	Mutex mutex;
+
+	// How many threads are executing.
+	uint activeThreads;
+	bool exitFlag;
+
+	import core.stdc.pthread;
+	pthread_t[] threads;
+
+	// Current work to do.
+	void delegate(uint) work;
+	// How many threads should execute the work
+	uint scheduled;
+
+	static void* threadEntry(void* ctx) {
+		// detach this thread -- it should not be scanned or stopped.
+		import d.gc.thread;
+		detachSelf();
+		auto pool = cast(shared(ThreadPool*)) ctx;
+		pool.executeWork();
+		return null;
+	}
+
+public:
+
+	void startThreads(pthread_t[] threadBuffer) shared {
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		(cast(ThreadPool*) &this).startThreadsImpl(threadBuffer);
+	}
+
+	void dispatch(void delegate(uint) work, uint count,
+	              bool useThisThread) shared {
+		{
+			mutex.lock();
+			scope(exit) mutex.unlock();
+
+			useThisThread = (cast(ThreadPool*) &this).dispatchImpl(work, count)
+				&& useThisThread;
+		}
+
+		if (!useThisThread) {
+			return;
+		}
+
+		// Utilize this thread to do some work as well.
+		uint idx;
+		while (getWorkMainThread(idx)) {
+			work(idx);
+		}
+	}
+
+	void waitForIdle() shared {
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		auto tp = cast(ThreadPool*) &this;
+		mutex.waitFor(tp.allThreadsIdle);
+	}
+
+	// joinAllThreads after current work is done
+	void joinAll() shared {
+		{
+			mutex.lock();
+			scope(exit) mutex.unlock();
+
+			(cast(ThreadPool*) &this).stopAllThreads();
+		}
+
+		(cast(ThreadPool*) &this).joinAllThreadsImpl();
+	}
+
+private:
+	void startThreadsImpl(pthread_t[] threadBuffer) {
+		assert(threads.length == 0);
+
+		threads = threadBuffer;
+		this.threads = threadBuffer;
+		activeThreads = cast(uint) threadBuffer.length;
+		foreach (ref tid; threads) {
+			pthread_create(&tid, null, threadEntry, cast(void*) &this);
+		}
+	}
+
+	bool dispatchImpl(void delegate(uint) work, uint count) {
+		assert(mutex.isHeld(), "Mutex not held!");
+		auto sharedThis = cast(shared(ThreadPool)*) &this;
+		sharedThis.mutex.waitFor(noMoreWork);
+
+		assert(scheduled == 0);
+
+		this.work = work;
+		this.scheduled = count;
+		import core.stdc.stdio;
+
+		// Return true if the current idle threads cannot consume all the work.
+		return activeThreads + scheduled > threads.length;
+	}
+
+	void stopAllThreads() {
+		assert(mutex.isHeld(), "Mutex not held!");
+		auto sharedThis = cast(shared(ThreadPool)*) &this;
+		sharedThis.mutex.waitFor(noMoreWork);
+		assert(scheduled == 0);
+
+		exitFlag = true;
+		sharedThis.mutex.waitFor(allThreadsIdle);
+	}
+
+	void joinAllThreadsImpl() {
+		assert(exitFlag);
+		assert(scheduled == 0);
+		assert(activeThreads == 0);
+		void* ret;
+		foreach (tid; threads) {
+			pthread_join(tid, &ret);
+		}
+
+		threads = [];
+	}
+
+	bool noMoreWork() {
+		return scheduled == 0;
+	}
+
+	bool allThreadsIdle() {
+		return activeThreads == 0;
+	}
+
+	void executeWork() shared {
+		void delegate(uint) workItem;
+		uint idx;
+		while (getWork(workItem, idx)) {
+			workItem(idx);
+		}
+	}
+
+	bool getWork(ref void delegate(uint) workItem, ref uint idx) shared {
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		return (cast(ThreadPool*) &this).getWorkImpl(workItem, idx);
+	}
+
+	bool getWorkMainThread(ref uint idx) shared {
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		return (cast(ThreadPool*) &this).getWorkMainThreadImpl(idx);
+	}
+
+	bool getWorkMainThreadImpl(ref uint idx) {
+		assert(mutex.isHeld(), "Mutex not held!");
+
+		if (scheduled == 0) {
+			return false;
+		}
+
+		scheduled -= 1;
+		idx = scheduled;
+		return true;
+	}
+
+	bool getWorkImpl(ref void delegate(uint) workItem, ref uint idx) {
+		assert(mutex.isHeld(), "Mutex not held!");
+
+		assert(activeThreads > 0);
+		activeThreads -= 1;
+
+		auto sharedThis = cast(shared(ThreadPool)*) &this;
+		sharedThis.mutex.waitFor(workReadyOrQuit);
+		if (exitFlag) {
+			return false;
+		}
+
+		assert(scheduled > 0);
+
+		workItem = work;
+
+		activeThreads += 1;
+		scheduled -= 1;
+		idx = scheduled;
+
+		return true;
+	}
+
+	bool workReadyOrQuit() {
+		return exitFlag || scheduled > 0;
+	}
+}

--- a/sdlib/d/gc/tstate.d
+++ b/sdlib/d/gc/tstate.d
@@ -62,7 +62,7 @@ public:
 		}
 	}
 
-	void detach() {
+	void assumeDetached() {
 		auto s = state.load();
 		while (true) {
 			auto n = s - SuspendState.Signaled + SuspendState.Detached;
@@ -74,6 +74,17 @@ public:
 				break;
 			}
 		}
+	}
+
+	void detach() {
+		import d.gc.tcache;
+		assert(&threadCache.state is &this,
+		       "Cannot detach manually from outside the thread!");
+
+		// should only ever be called while in a normal thread state.
+		size_t s = RunningState;
+		auto succeeded = state.casWeak(s, SuspendState.Detached);
+		assert(succeeded);
 	}
 
 	bool onSuspendSignal() {


### PR DESCRIPTION
When this is merged, we will replace the parallel scan with this thread pool.

Next step will be to start the threads before stopping the world to prevent deadlocks.

Then we can work on some parallel collect features.