### PR TITLE
Replace invalid use of toStringz with concatenation.

### DIFF
--- a/src/source/name.d
+++ b/src/source/name.d
@@ -103,8 +103,7 @@ public:
 		}
 
 		// As we are cloning, make sure it is 0 terminated as to pass to C.
-		import std.string;
-		auto s = str.toStringz()[0 .. str.length];
+		auto s = cast(string) (str ~ '\0')[0 .. str.length];
 
 		// Make sure we do not keep around slice of potentially large input.
 		scope(exit) assert(str.ptr !is s.ptr, s);
@@ -121,6 +120,13 @@ public:
 			writeln(lookups[s], "\t=> ", s);
 		}
 	}
+}
+
+unittest {
+	string nameWithZeros = "hello\0world\0";
+	auto nm = NameManager.get();
+	auto s = nm.getName(nameWithZeros);
+	assert(nm.names[s.id] == nameWithZeros);
 }
 
 private:


### PR DESCRIPTION
Note here: https://github.com/dlang/phobos/blob/dbc09d8230f0e273af8a78546e5431a7783478b5/std/string.d#L368

If you pass it a string that has null characters in it, this assertion will fail when phobos is compiled with debug mode.

And in SDC we are using this to intern float values here: https://github.com/snazzy-d/sdc/blob/229c066f2d511d05ead6ac8da456c7ca64d1783c/src/source/packedfloat.d#L189