### PR TITLE
Enter busy state while destroying threads

### DIFF
--- a/sdlib/d/gc/thread.d
+++ b/sdlib/d/gc/thread.d
@@ -38,6 +38,13 @@ void createThread() {
 }
 
 void destroyThread() {
+	/**
+	 * Note: we are about to remove the thread from the active thread
+	 * list, we do not want to suspend, because the thread will never be
+	 * woken up. Therefore -- no exitBusyState.
+	 */
+	enterBusyState();
+
 	threadCache.destroyThread();
 	gThreadState.remove(&threadCache);
 }


### PR DESCRIPTION
The mThreadList lock is taken while doing a whole host of things, such as scanning, or signaling.

If we don't enter the busy state, we could be paused while holding the lock to remove the thread, and this will deadlock the collection.