### PR TITLE
[GC] Add configuration option for setting the number of scanning threads at runtime

### DIFF
--- a/sdlib/d/gc/collector.d
+++ b/sdlib/d/gc/collector.d
@@ -56,7 +56,8 @@ private:
 		prepareGCCycle();
 
 		import d.gc.scanner;
-		shared(Scanner) scanner = Scanner(gcCycle, managedAddressSpace);
+		shared(Scanner) scanner = Scanner(gCollectorState.scanningThreads,
+		                                  gcCycle, managedAddressSpace);
 
 		// Go on and on until all worklists are empty.
 		scanner.mark();
@@ -161,6 +162,9 @@ private:
 	// Keep a minimum overhead of 12.5% over the current heap size.
 	ubyte lgMinOverhead = 3;
 
+	// How many threads to run for scanning. 0 to use the cpu count.
+	uint scanningThreads = 0;
+
 public:
 	bool maybeRunGCCycle(ref Collector collector) shared {
 		// Do not unnecessarily create contention on this mutex.
@@ -170,6 +174,13 @@ public:
 
 		scope(exit) mutex.unlock();
 		return (cast(CollectorState*) &this).maybeRunGCCycleImpl(collector);
+	}
+
+	void setScanningThreads(uint nThreads) shared {
+		mutex.lock();
+		scope(exit) mutex.unlock();
+
+		(cast(CollectorState*) &this).scanningThreads = nThreads;
 	}
 
 private:

--- a/sdlib/d/gc/scanner.d
+++ b/sdlib/d/gc/scanner.d
@@ -25,6 +25,12 @@ private:
 
 public:
 	this(uint threadCount, ubyte gcCycle, AddressRange managedAddressSpace) {
+		if (threadCount == 0) {
+			import d.gc.cpu;
+			threadCount = getCoreCount();
+			assert(threadCount >= 1, "Expected at least one thread!");
+		}
+
 		activeThreads = threadCount;
 
 		this._gcCycle = gcCycle;
@@ -32,12 +38,7 @@ public:
 	}
 
 	this(ubyte gcCycle, AddressRange managedAddressSpace) {
-		import d.gc.cpu;
-		auto nthreads = getCoreCount();
-		assert(nthreads >= 1, "Expected at least one thread!");
-
-		// nthreads = 1;
-		this(nthreads, gcCycle, managedAddressSpace);
+		this(0, gcCycle, managedAddressSpace);
 	}
 
 	@property

--- a/sdlib/dmd/gc.d
+++ b/sdlib/dmd/gc.d
@@ -133,3 +133,8 @@ void* __sd_gc_alloc_from_druntime(size_t size, uint flags, void* finalizer) {
 
 	return threadCache.alloc(size, containsPointers, false);
 }
+
+void __sd_gc_set_scanning_thread_count(uint nThreads) {
+	import d.gc.collector;
+	gCollectorState.setScanningThreads(nThreads);
+}


### PR DESCRIPTION
This is to support a druntime GC option: https://github.com/dlang/dmd/blob/92bee161399aee193cbda2ea158edde3506d3e0f/druntime/src/core/gc/config.d#L26

Used here in the current GC:
https://github.com/dlang/dmd/blob/92bee161399aee193cbda2ea158edde3506d3e0f/druntime/src/core/internal/gc/impl/conservative/gc.d#L3380