### PR TITLE
Free TLS segments directly to the arena, do not use the thread cache.

### DIFF
--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -154,10 +154,8 @@ public:
 		state.enterBusyState();
 		scope(exit) state.exitBusyState();
 
-		auto tls = clearTLSSegments();
-		if (tls.ptr !is null) {
-			free(tls.ptr);
-		}
+		free(tlsSegments.ptr);
+		tlsSegments = [];
 
 		flush();
 	}
@@ -638,11 +636,6 @@ private:
 
 		import d.gc.range;
 		tlsSegments[index] = makeRange(range);
-	}
-
-	const(void*)[][] clearTLSSegments() {
-		scope(exit) tlsSegments = [];
-		return tlsSegments;
 	}
 
 private:

--- a/sdlib/d/gc/tcache.d
+++ b/sdlib/d/gc/tcache.d
@@ -154,7 +154,11 @@ public:
 		state.enterBusyState();
 		scope(exit) state.exitBusyState();
 
-		clearTLSSegments();
+		auto tls = clearTLSSegments();
+		if (tls.ptr !is null) {
+			free(tls.ptr);
+		}
+
 		flush();
 	}
 
@@ -493,25 +497,6 @@ private:
 	}
 
 	/**
-	 * Free directly to the arena, skip all threadCache metadata/caches.
-	 * Safe to call from a signal handler.
-	 */
-	void freeToArena(void* ptr) {
-		import d.gc.emap, d.gc.base;
-		auto emap = CachedExtentMap(&gExtentMap, &gBase);
-
-		auto aptr = alignDown(ptr, PageSize);
-		auto pd = emap.lookup(aptr);
-		if (!pd.isSlab()) {
-			pd.arena.freeLarge(emap, pd.extent);
-			return;
-		}
-
-		const(void*)[] worklist = (cast(const(void*)*) &ptr)[0 .. 1];
-		pd.arena.batchFree(emap, worklist, &pd);
-	}
-
-	/**
 	 * Bytes accounting and bin maintenance.
 	 */
 	void triggerAllocationEvent(size_t bytes) {
@@ -655,14 +640,9 @@ private:
 		tlsSegments[index] = makeRange(range);
 	}
 
-	void clearTLSSegments() {
-		if (tlsSegments.ptr !is null) {
-			// Do not call free directly, because that might try to
-			// change the cache bins, and this can be called from a
-			// signal handler.
-			freeToArena(tlsSegments.ptr);
-			tlsSegments = [];
-		}
+	const(void*)[][] clearTLSSegments() {
+		scope(exit) tlsSegments = [];
+		return tlsSegments;
 	}
 
 private:

--- a/sdlib/dmd/thread.d
+++ b/sdlib/dmd/thread.d
@@ -66,12 +66,13 @@ void __sd_gc_pre_suspend_hook(void* stackTop) {
 		 * pushed on it.
 		 */
 		import d.gc.tcache;
-		auto tls = threadCache.clearTLSSegments();
+		auto tls = threadCache.tlsSegments;
 		if (tls.ptr !is null) {
-			// Arena needs a CachedExtentMap for freeing pages. Copy the
-			// threadCache to a temporary, so we don't mess with it.
-			auto emap = threadCache.emap;
+			threadCache.tlsSegments = [];
 
+			// Arena needs a CachedExtentMap for freeing pages.
+			auto emap =
+				CachedExtentMap(threadCache.emap.emap, threadCache.emap.base);
 			arenaFree(emap, tls.ptr);
 		}
 	}


### PR DESCRIPTION
This avoids a situation where the thread cache doesn't suddenly change inside a signal handler.