### PR TITLE
Remove racy check from sharedlock unittest

### DIFF
--- a/sdlib/d/sync/sharedlock.d
+++ b/sdlib/d/sync/sharedlock.d
@@ -514,7 +514,6 @@ unittest exclusiveAndSharedLock {
 	lock.mutex.unlock();
 
 	assert(lock.count == SharedLock.Exclusive + 2);
-	assert(!lock.mutex.isHeld());
 	assert(exclusiveState.load() == 1);
 	sharedState.waitForState(2, 0);
 


### PR DESCRIPTION
This was falling in the symgc project, very occasionally.

What was happening:
1. unittest main thread unlocks the lock
2. exclusive locker thread is woken up to check its condition again, and takes the lock
3. Race! sometimes this lock is held, sometimes it isn't.