### PR TITLE
Remove unnecessary ec fetch in scanner hot loop

### DIFF
--- a/sdlib/d/gc/scanner.d
+++ b/sdlib/d/gc/scanner.d
@@ -487,7 +487,6 @@ private:
 			return false;
 		}
 
-		auto ec = pd.extentClass;
 		return e.markDenseSlot(index);
 	}
 


### PR DESCRIPTION
In one test was seeing a significant improvement by removing this.

This line was a legacy piece of code that got left from a refactor in #406 